### PR TITLE
build(docs): fix basic build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,6 @@ extensions.extend(
         "sphinx.ext.viewcode",
         "sphinx.ext.coverage",
         "sphinx.ext.doctest",
-        "sphinx-pydantic",
         "sphinx_toolbox",
         "sphinx_toolbox.more_autodoc",
         "sphinx.ext.autodoc",  # Must be loaded after more_autodoc
@@ -54,6 +53,14 @@ extensions.extend(
 )
 
 # endregion
+
+exclude_patterns = [
+    "tutorials/index.rst",
+    "how-to-guides/index.rst",
+    "explanation/index.rst",
+    "reference/index.rst",
+    "release-notes/index.rst",
+]
 
 # region Options for extensions
 # Intersphinx extension


### PR DESCRIPTION
@jahn-junior This is a code dump to fix the doc build. We can rebase this later.
