### PR TITLE
fix: prepend field name before parsing with PyYAML

### DIFF
--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -449,15 +449,11 @@ def build_examples_block(field_name: str, example: str) -> nodes.literal_block:
         nodes.literal_block: A literal block containing a well-formed YAML example.
 
     """
+    example = f"{field_name.rsplit('.', maxsplit=1)[-1]}: {example}"
     try:
         yaml_str = yaml.dump(yaml.safe_load(example), default_flow_style=False)
         yaml_str = yaml_str.rstrip("\n")
         yaml_str = yaml_str.replace("- ", "  - ").removesuffix("...")
-        if len(yaml_str.splitlines()) == 1:
-            yaml_str = f"{field_name.rsplit('.', maxsplit=1)[-1]}: {yaml_str}"
-        else:
-            yaml_str = textwrap.indent(yaml_str, "  ")
-            yaml_str = f"{field_name.rsplit('.', maxsplit=1)[-1]}:\n{yaml_str}"
     except yaml.YAMLError as e:
         warnings.warn(
             f"Invalid YAML for field {field_name}: {e}",

--- a/tests/unit/test_supporting_functions.py
+++ b/tests/unit/test_supporting_functions.py
@@ -204,7 +204,7 @@ def test_build_valid_examples_block():
     expected = nodes.literal_block(text=yaml_str)
     expected["language"] = "yaml"
 
-    actual = build_examples_block("test", "subkey: [good, nice]")
+    actual = build_examples_block("test", "{subkey: [good, nice]}")
 
     # comparing strings because docutils `__eq__`
     # method compares by identity rather than state
@@ -214,12 +214,10 @@ def test_build_valid_examples_block():
 # Test for `build_examples_block` with invalid input
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_build_invalid_examples_block():
-    yaml_str = "{[ oops"
-
-    expected = nodes.literal_block(text=yaml_str)
+    expected = nodes.literal_block(text="test: {[ oops")
     expected["language"] = "yaml"
 
-    actual = build_examples_block("", yaml_str)
+    actual = build_examples_block("test", "{[ oops")
 
     # comparing strings because docutils `__eq__`
     # method compares by identity rather than state


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Resolves https://github.com/canonical/pydantic-kitbash/issues/13
