### PR TITLE
feat: improve field type output

### DIFF
--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -696,12 +696,13 @@ def format_type_string(type_str: type[object] | typing.Any) -> str:  # noqa: ANN
     """
     result = ""
 
-    pattern = r"Literal\[(.*?)\]"
-    if match := re.search(pattern, str(type_str)):
+    if match := re.search(r"Literal\[(.*?)\]", str(type_str)):
         string_list = match.group(1)
         list_items = re.findall(r"'([^']*)'", string_list)
         result = f"Any of: {list_items}"
     elif type_str is not None:
-        result = type_str.__name__
+        result = str(type_str).replace("project.", "").replace("typing.", "")
+        if type_match := re.match(r"<[^ ]+ '([^']+)'>", str(type_str)):
+            result = type_match.group(1).split(".")[-1]
 
     return result

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -47,8 +47,7 @@ class KitbashFieldDirective(SphinxDirective):
 
     option_spec = {
         "skip-examples": bool,
-        "skip-type": bool,
-        "override-name": str,
+        "override-type": str,
         "prepend-name": str,
         "append-name": str,
     }
@@ -89,7 +88,7 @@ class KitbashFieldDirective(SphinxDirective):
         enum_values = None
 
         # if field is optional "normal" type (e.g., str | None)
-        if isinstance(field_params.annotation, types.UnionType):
+        if typing.get_origin(field_params.annotation) is types.UnionType:
             union_args = typing.get_args(field_params.annotation)
             field_type: str | None = format_type_string(union_args[0])
             if issubclass(union_args[0], enum.Enum):
@@ -126,12 +125,10 @@ class KitbashFieldDirective(SphinxDirective):
         deprecation_warning = is_deprecated(pydantic_class, field_name)
 
         # Remove type if :skip-type: directive option was used
-        field_type = None if "skip-type" in self.options else field_type
+        field_type = self.options.get("override-type", field_type)
 
         # Remove examples if :skip-examples: directive option was used
         examples = None if "skip-examples" in self.options else examples
-
-        field_alias = self.options.get("override-name", field_alias)
 
         # Get strings to concatenate with `field_alias`
         name_prefix = self.options.get("prepend-name", "")

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -175,16 +175,13 @@ def test_kitbash_field(fake_field_directive: FakeFieldDirective):
     ("fake_field_directive", "title_text"),
     [
         pytest.param(
-            {"options": {"override-name": "override"}}, "override", id="override-name"
-        ),
-        pytest.param(
             {"options": {"prepend-name": "app"}}, "app.test", id="prepend-name"
         ),
         pytest.param({"options": {"append-name": "app"}}, "test.app", id="append-name"),
     ],
     indirect=["fake_field_directive"],
 )
-def test_kitbash_field_options(
+def test_kitbash_field_name_options(
     fake_field_directive: FakeFieldDirective, title_text: str
 ):
     expected = nodes.section(ids=[title_text])
@@ -216,9 +213,9 @@ def test_kitbash_field_options(
 
 
 @pytest.mark.parametrize(
-    "fake_field_directive", [{"options": {"skip-type": True}}], indirect=True
+    "fake_field_directive", [{"options": {"override-type": "override"}}], indirect=True
 )
-def test_kitbash_field_skip_type(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
     expected = nodes.section(ids=["test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
@@ -229,6 +226,10 @@ def test_kitbash_field_skip_type(fake_field_directive: FakeFieldDirective):
     .. important::
 
         Deprecated. ew.
+
+    **Type**
+
+    ``override``
 
     **Description**
 


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

* remove `:override-name:` option
* replace `:skip-type:` option with `:override-type:` option
* make type output more descriptive

Types are oversimplified in the current version. This PR changes the behavior so that the full type is displayed, with the option to override it if it gets too messy.

