### PR TITLE
feat: add :skip-description: option

### DIFF
--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -696,12 +696,13 @@ def format_type_string(type_str: type[object] | typing.Any) -> str:  # noqa: ANN
     """
     result = ""
 
-    pattern = r"Literal\[(.*?)\]"
-    if match := re.search(pattern, str(type_str)):
+    if match := re.search(r"Literal\[(.*?)\]", str(type_str)):
         string_list = match.group(1)
         list_items = re.findall(r"'([^']*)'", string_list)
         result = f"Any of: {list_items}"
     elif type_str is not None:
-        result = type_str.__name__
+        result = str(type_str).replace("project.", "").replace("typing.", "")
+        if type_match := re.match(r"<[^ ]+ '([^']+)'>", str(type_str)):
+            result = type_match.group(1).split(".")[-1]
 
     return result

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -159,6 +159,7 @@ class KitbashModelDirective(SphinxDirective):
 
     option_spec = {
         "include-deprecated": str,
+        "skip-description": bool,
         "prepend-name": str,
         "append-name": str,
     }
@@ -189,7 +190,7 @@ class KitbashModelDirective(SphinxDirective):
         # User-provided description overrides model docstring
         if self.content:
             class_node += parse_rst_description("\n".join(self.content))
-        elif pydantic_class.__doc__:
+        elif pydantic_class.__doc__ and "skip-description" not in self.options:
             class_node += parse_rst_description(pydantic_class.__doc__)
 
         # Check if user provided a list of deprecated fields to include

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -49,9 +49,9 @@ class KitbashFieldDirective(SphinxDirective):
     option_spec = {
         "skip-examples": directives.flag,
         "skip-type": directives.flag,
-        "override-name": str,
-        "prepend-name": str,
-        "append-name": str,
+        "override-name": directives.unchanged,
+        "prepend-name": directives.unchanged,
+        "append-name": directives.unchanged,
     }
 
     def run(self) -> list[nodes.Node]:
@@ -90,7 +90,7 @@ class KitbashFieldDirective(SphinxDirective):
         enum_values = None
 
         # if field is optional "normal" type (e.g., str | None)
-        if isinstance(field_params.annotation, types.UnionType):
+        if typing.get_origin(field_params.annotation) is types.UnionType:
             union_args = typing.get_args(field_params.annotation)
             field_type: str | None = format_type_string(union_args[0])
             if issubclass(union_args[0], enum.Enum):
@@ -162,10 +162,10 @@ class KitbashModelDirective(SphinxDirective):
     final_argument_whitespace = True
 
     option_spec = {
-        "include-deprecated": str,
+        "include-deprecated": directives.unchanged,
         "skip-description": directives.flag,
-        "prepend-name": str,
-        "append-name": str,
+        "prepend-name": directives.unchanged,
+        "append-name": directives.unchanged,
     }
 
     def run(self) -> list[nodes.Node]:

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -34,6 +34,7 @@ import pydantic
 import yaml
 from docutils import nodes
 from docutils.core import publish_doctree  # type: ignore[reportUnknownVariableType]
+from docutils.parsers.rst import directives
 from pydantic.fields import FieldInfo
 from sphinx.util.docutils import SphinxDirective
 
@@ -46,8 +47,8 @@ class KitbashFieldDirective(SphinxDirective):
     final_argument_whitespace = True
 
     option_spec = {
-        "skip-examples": bool,
-        "skip-type": bool,
+        "skip-examples": directives.flag,
+        "skip-type": directives.flag,
         "override-name": str,
         "prepend-name": str,
         "append-name": str,
@@ -162,7 +163,7 @@ class KitbashModelDirective(SphinxDirective):
 
     option_spec = {
         "include-deprecated": str,
-        "skip-description": bool,
+        "skip-description": directives.flag,
         "prepend-name": str,
         "append-name": str,
     }

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -47,8 +47,7 @@ class KitbashFieldDirective(SphinxDirective):
 
     option_spec = {
         "skip-examples": bool,
-        "skip-type": bool,
-        "override-name": str,
+        "override-type": str,
         "prepend-name": str,
         "append-name": str,
     }
@@ -89,7 +88,7 @@ class KitbashFieldDirective(SphinxDirective):
         enum_values = None
 
         # if field is optional "normal" type (e.g., str | None)
-        if isinstance(field_params.annotation, types.UnionType):
+        if typing.get_origin(field_params.annotation) is types.UnionType:
             union_args = typing.get_args(field_params.annotation)
             field_type: str | None = format_type_string(union_args[0])
             if issubclass(union_args[0], enum.Enum):
@@ -126,12 +125,10 @@ class KitbashFieldDirective(SphinxDirective):
         deprecation_warning = is_deprecated(pydantic_class, field_name)
 
         # Remove type if :skip-type: directive option was used
-        field_type = None if "skip-type" in self.options else field_type
+        field_type = self.options.get("override-type", field_type)
 
         # Remove examples if :skip-examples: directive option was used
         examples = None if "skip-examples" in self.options else examples
-
-        field_alias = self.options.get("override-name", field_alias)
 
         # Get strings to concatenate with `field_alias`
         name_prefix = self.options.get("prepend-name", "")

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -175,16 +175,13 @@ def test_kitbash_field(fake_field_directive: FakeFieldDirective):
     ("fake_field_directive", "title_text"),
     [
         pytest.param(
-            {"options": {"override-name": "override"}}, "override", id="override-name"
-        ),
-        pytest.param(
             {"options": {"prepend-name": "app"}}, "app.test", id="prepend-name"
         ),
         pytest.param({"options": {"append-name": "app"}}, "test.app", id="append-name"),
     ],
     indirect=["fake_field_directive"],
 )
-def test_kitbash_field_options(
+def test_kitbash_field_name_options(
     fake_field_directive: FakeFieldDirective, title_text: str
 ):
     expected = nodes.section(ids=[title_text])
@@ -216,9 +213,9 @@ def test_kitbash_field_options(
 
 
 @pytest.mark.parametrize(
-    "fake_field_directive", [{"options": {"skip-type": True}}], indirect=True
+    "fake_field_directive", [{"options": {"override-type": "override"}}], indirect=True
 )
-def test_kitbash_field_skip_type(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
     expected = nodes.section(ids=["test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
@@ -229,6 +226,10 @@ def test_kitbash_field_skip_type(fake_field_directive: FakeFieldDirective):
     .. important::
 
         Deprecated. ew.
+
+    **Type**
+
+    ``override``
 
     **Description**
 

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -216,7 +216,7 @@ def test_kitbash_field_options(
 
 
 @pytest.mark.parametrize(
-    "fake_field_directive", [{"options": {"skip-type": True}}], indirect=True
+    "fake_field_directive", [{"options": {"skip-type": None}}], indirect=True
 )
 def test_kitbash_field_skip_type(fake_field_directive: FakeFieldDirective):
     expected = nodes.section(ids=["test"])
@@ -245,7 +245,7 @@ def test_kitbash_field_skip_type(fake_field_directive: FakeFieldDirective):
 
 @pytest.mark.parametrize(
     "fake_field_directive",
-    [{"model_field": "bad_example", "options": {"skip-examples": True}}],
+    [{"model_field": "bad_example", "options": {"skip-examples": None}}],
     indirect=True,
 )
 def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
@@ -376,7 +376,7 @@ def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
 
 @pytest.mark.parametrize(
     "fake_field_directive",
-    [{"model_field": "typing_union", "options": {"skip-examples": True}}],
+    [{"model_field": "typing_union", "options": {"skip-examples": None}}],
     indirect=True,
 )
 def test_kitbash_field_typing_union(fake_field_directive: FakeFieldDirective):

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -175,13 +175,16 @@ def test_kitbash_field(fake_field_directive: FakeFieldDirective):
     ("fake_field_directive", "title_text"),
     [
         pytest.param(
+            {"options": {"override-name": "override"}}, "override", id="override-name"
+        ),
+        pytest.param(
             {"options": {"prepend-name": "app"}}, "app.test", id="prepend-name"
         ),
         pytest.param({"options": {"append-name": "app"}}, "test.app", id="append-name"),
     ],
     indirect=["fake_field_directive"],
 )
-def test_kitbash_field_name_options(
+def test_kitbash_field_options(
     fake_field_directive: FakeFieldDirective, title_text: str
 ):
     expected = nodes.section(ids=[title_text])
@@ -213,9 +216,9 @@ def test_kitbash_field_name_options(
 
 
 @pytest.mark.parametrize(
-    "fake_field_directive", [{"options": {"override-type": "override"}}], indirect=True
+    "fake_field_directive", [{"options": {"skip-type": True}}], indirect=True
 )
-def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_skip_type(fake_field_directive: FakeFieldDirective):
     expected = nodes.section(ids=["test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
@@ -226,10 +229,6 @@ def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
     .. important::
 
         Deprecated. ew.
-
-    **Type**
-
-    ``override``
 
     **Description**
 

--- a/tests/unit/test_kitbash_model.py
+++ b/tests/unit/test_kitbash_model.py
@@ -262,7 +262,7 @@ def test_kitbash_model(fake_model_directive):
     [
         {
             "options": {
-                "skip-description": True,
+                "skip-description": None,
             }
         }
     ],

--- a/tests/unit/test_kitbash_model.py
+++ b/tests/unit/test_kitbash_model.py
@@ -134,6 +134,8 @@ class MockEnum(enum.Enum):
 
 
 class MockModel(pydantic.BaseModel):
+    """this is the model's docstring"""
+
     mock_field: int = pydantic.Field(
         description="description",
         alias="test",
@@ -204,6 +206,69 @@ def test_kitbash_model_invalid(fake_model_directive):
 
 
 def test_kitbash_model(fake_model_directive):
+    expected = list(publish_doctree(MockModel.__doc__).children)
+
+    uniontype_section = nodes.section(ids=["uniontype_field"])
+    uniontype_section["classes"].append("kitbash-entry")
+    uniontype_title = nodes.title(text="uniontype_field")
+    uniontype_section += uniontype_title
+
+    uniontype_rst = strip_whitespace(UNIONTYPE_RST)
+    uniontype_section += publish_doctree(uniontype_rst).children
+    expected.append(uniontype_section)
+
+    enum_section = nodes.section(ids=["enum_field"])
+    enum_section["classes"].append("kitbash-entry")
+    enum_title = nodes.title(text="enum_field")
+    enum_section += enum_title
+
+    enum_rst = strip_whitespace(ENUM_RST)
+    enum_section += publish_doctree(enum_rst).children
+
+    enum_value_container = nodes.container()
+    enum_value_container += publish_doctree(LIST_TABLE_RST).children
+    enum_section += enum_value_container
+    expected.append(enum_section)
+
+    enum_uniontype_section = nodes.section(ids=["enum_uniontype"])
+    enum_uniontype_section["classes"].append("kitbash-entry")
+    enum_uniontype_title = nodes.title(text="enum_uniontype")
+    enum_uniontype_section += enum_uniontype_title
+
+    enum_uniontype_rst = strip_whitespace(ENUM_RST)
+    enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
+
+    enum_uniontype_value_container = nodes.container()
+    enum_uniontype_value_container += publish_doctree(LIST_TABLE_RST).children
+    enum_uniontype_section += enum_uniontype_value_container
+    expected.append(enum_uniontype_section)
+
+    typing_union_section = nodes.section(ids=["typing_union"])
+    typing_union_section["classes"].append("kitbash-entry")
+    typing_union_title = nodes.title(text="typing_union")
+    typing_union_section += typing_union_title
+
+    typing_union_rst = strip_whitespace(TYPING_UNION_RST)
+    typing_union_section += publish_doctree(typing_union_rst).children
+    expected.append(typing_union_section)
+
+    actual = fake_model_directive.run()
+
+    assert str(expected) == str(actual)
+
+
+@pytest.mark.parametrize(
+    "fake_model_directive",
+    [
+        {
+            "options": {
+                "skip-description": True,
+            }
+        }
+    ],
+    indirect=True,
+)
+def test_kitbash_model_skip_description(fake_model_directive):
     expected = []
 
     uniontype_section = nodes.section(ids=["uniontype_field"])
@@ -259,10 +324,7 @@ def test_kitbash_model(fake_model_directive):
     "fake_model_directive", [{"content": ["``Test content``"]}], indirect=True
 )
 def test_kitbash_model_content(fake_model_directive):
-    expected = []
-
-    rendered_content = publish_doctree("``Test content``").children
-    expected = list(rendered_content)
+    expected = list(publish_doctree("``Test content``").children)
 
     uniontype_section = nodes.section(ids=["uniontype_field"])
     uniontype_section["classes"].append("kitbash-entry")
@@ -325,7 +387,7 @@ def test_kitbash_model_content(fake_model_directive):
     indirect=True,
 )
 def test_kitbash_model_include_deprecated(fake_model_directive):
-    expected = []
+    expected = list(publish_doctree("this is the model's docstring").children)
 
     mock_field_section = nodes.section(ids=["test"])
     mock_field_section["classes"].append("kitbash-entry")
@@ -397,7 +459,7 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     indirect=True,
 )
 def test_kitbash_model_prepend_name(fake_model_directive):
-    expected = []
+    expected = list(publish_doctree("this is the model's docstring").children)
 
     uniontype_section = nodes.section(ids=["prefix.uniontype_field"])
     uniontype_section["classes"].append("kitbash-entry")
@@ -460,7 +522,7 @@ def test_kitbash_model_prepend_name(fake_model_directive):
     indirect=True,
 )
 def test_kitbash_model_append_name(fake_model_directive):
-    expected = []
+    expected = list(publish_doctree("this is the model's docstring").children)
 
     uniontype_section = nodes.section(ids=["uniontype_field.suffix"])
     uniontype_section["classes"].append("kitbash-entry")


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Addresses https://github.com/canonical/pydantic-kitbash/issues/18

This PR adds a `:skip-description:` option to the `kitbash-model` directive that allows users to hide the model's docstring from the output.

Drive-by: Fix `option_spec` value types
