### PR TITLE
fix: correct typo in table header

### DIFF
--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -550,7 +550,7 @@ def create_table_node(values: list[list[str]]) -> nodes.container:
     header_row = nodes.row()
 
     values_entry = nodes.entry()
-    values_entry += nodes.paragraph(text="Values")
+    values_entry += nodes.paragraph(text="Value")
     header_row += values_entry
 
     desc_entry = nodes.entry()

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -32,7 +32,7 @@ LIST_TABLE_RST = """
 .. list-table::
     :header-rows: 1
 
-    * - Values
+    * - Value
       - Description
     * - ``value1``
       - The first value.

--- a/tests/unit/test_supporting_functions.py
+++ b/tests/unit/test_supporting_functions.py
@@ -35,7 +35,6 @@ from pydantic_kitbash.directives import (
     get_enum_member_docstring,
     get_enum_values,
     get_optional_annotated_field_data,
-    get_optional_field_data,
     is_deprecated,
     is_enum_type,
     parse_rst_description,
@@ -104,7 +103,7 @@ TABLE_RST = """\
 .. list-table::
     :header-rows: 1
 
-    * - Values
+    * - Value
       - Description
     * - ``1.1``
       - 1.2


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Fixes typo in the header row of the enum values table.

This slipped past me because I was doing all of the list tables manually in Snapcraft :angry: