### PR TITLE
fix: indent YAML list items

### DIFF
--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -45,6 +45,14 @@ TYPE_STR_EXPR = re.compile(r"<[^ ]+ '([^']+)'>")
 MODULE_PREFIX_EXPR = re.compile(r"\b(?:\w+\.)+(\w+)")
 
 
+class PrettyListDumper(yaml.Dumper):
+    """Custom YAML dumper for indenting lists."""
+
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:  # noqa: ARG002, FBT001, FBT002
+        """Override the default increase_indent method from Emitter."""
+        return super().increase_indent(flow, False)  # noqa: FBT003
+
+
 class FieldEntry:
     """Contains any field attributes that will be displayed in directive output."""
 
@@ -507,9 +515,14 @@ def build_examples_block(field_name: str, example: str) -> nodes.literal_block:
     """
     example = f"{field_name.rsplit('.', maxsplit=1)[-1]}: {example}"
     try:
-        yaml_str = yaml.dump(yaml.safe_load(example), default_flow_style=False)
+        yaml_str = yaml.dump(
+            yaml.safe_load(example),
+            Dumper=PrettyListDumper,
+            default_flow_style=False,
+            sort_keys=False,
+        )
         yaml_str = yaml_str.rstrip("\n")
-        yaml_str = yaml_str.replace("- ", "  - ").removesuffix("...")
+        yaml_str = yaml_str.removesuffix("...")
     except yaml.YAMLError as e:
         warnings.warn(
             f"Invalid YAML for field {field_name}: {e}",

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -37,20 +37,13 @@ from docutils.core import publish_doctree  # type: ignore[reportUnknownVariableT
 from docutils.parsers.rst import directives
 from pydantic.fields import FieldInfo
 from sphinx.util.docutils import SphinxDirective
+from typing_extensions import override
 
 # Compiled regex patterns for type formatting
 LITERAL_LIST_EXPR = re.compile(r"Literal\[(.*?)\]")
 LIST_ITEM_EXPR = re.compile(r"'([^']*)'")
 TYPE_STR_EXPR = re.compile(r"<[^ ]+ '([^']+)'>")
 MODULE_PREFIX_EXPR = re.compile(r"\b(?:\w+\.)+(\w+)")
-
-
-class PrettyListDumper(yaml.Dumper):
-    """Custom YAML dumper for indenting lists."""
-
-    def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:  # noqa: ARG002, FBT001, FBT002
-        """Override the default increase_indent method from Emitter."""
-        return super().increase_indent(flow, False)  # noqa: FBT003
 
 
 class FieldEntry:
@@ -72,6 +65,15 @@ class FieldEntry:
         self.description = None
         self.enum_values = None
         self.examples = None
+
+
+@override
+class PrettyListDumper(yaml.Dumper):
+    """Custom YAML dumper for indenting lists."""
+
+    @override
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> None:
+        return super().increase_indent(flow, indentless=False)
 
 
 class KitbashFieldDirective(SphinxDirective):

--- a/tests/unit/test_supporting_functions.py
+++ b/tests/unit/test_supporting_functions.py
@@ -128,6 +128,12 @@ This is the key description
 
 """
 
+LIST_YAML = """\
+key:
+  - item1: val1
+    item2: val2
+"""
+
 
 # Test for `find_field_data`
 def test_find_fieldinfo():
@@ -247,6 +253,16 @@ def test_build_valid_examples_block():
 
     # comparing strings because docutils `__eq__`
     # method compares by identity rather than state
+    assert str(expected) == str(actual)
+
+
+def test_build_list_example():
+    """Test for build_examples_block when rendering lists of dicts."""
+    expected = nodes.literal_block(text=(LIST_YAML.rstrip("\n")))
+    expected["language"] = "yaml"
+
+    actual = build_examples_block("key", "[{item1: val1, item2: val2}]")
+
     assert str(expected) == str(actual)
 
 


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

Works around a list indentation issue in PyYAML.

Instead of the default behavior:

```yaml
key1:
  key2:
  - list_item1
    list_item2
```

We'll now get:

```yaml
key1:
  key2:
    - list_item1
      list_item2
```

I have yet to find a testing solution for example blocks. The rendered output from the extension is indistinguishable from Sphinx code blocks, but they handle inline formatting differently, so the nodes can't be compared directly.