### PR TITLE
feat: add labels to entries

### DIFF
--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -518,6 +518,9 @@ def create_field_node(field_entry: FieldEntry) -> nodes.section:
     field_node["classes"] = ["kitbash-entry"]
     title_node = nodes.title(text=field_entry.alias)
     field_node += title_node
+    target_node = nodes.target()
+    target_node["refid"] = field_entry.label
+    field_node += target_node
 
     if field_entry.deprecation_warning:
         deprecated_node = nodes.important()

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -512,7 +512,7 @@ def create_field_node(field_entry: FieldEntry) -> nodes.section:
         nodes.section: A section containing well-formed output for each provided field attribute.
 
     """
-    field_node = nodes.section(ids=[field_entry.label])
+    field_node = nodes.section(ids=[field_entry.alias, field_entry.label])
     field_node["classes"] = ["kitbash-entry"]
     title_node = nodes.title(text=field_entry.alias)
     field_node += title_node

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -168,9 +168,9 @@ class KitbashFieldDirective(SphinxDirective):
             else ""
         )
 
-        label_text = self.options.get("label", f"{source_file}{field_entry.alias}")
-
-        field_entry.label = nodes.make_id(label_text)
+        field_entry.label = self.options.get(
+            "label", f"{source_file}{field_entry.alias}"
+        )
 
         # Get strings to concatenate with `field_alias`
         name_prefix = self.options.get("prepend-name", "")
@@ -310,11 +310,9 @@ class KitbashModelDirective(SphinxDirective):
                     else ""
                 )
 
-                label_text = self.options.get(
+                field_entry.label = self.options.get(
                     "label", f"{source_file}{field_entry.alias}"
                 )
-
-                field_entry.label = nodes.make_id(label_text)
 
                 # Get strings to concatenate with `field_alias`
                 name_prefix = self.options.get("prepend-name", "")

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -185,8 +185,9 @@ class KitbashFieldDirective(SphinxDirective):
         )
 
         if state:
+            # Add cross-referencing details to Sphinx's domain data
             self.env.app.env.domaindata["std"]["labels"][field_entry.label] = (
-                self.env.docname,
+                self.env.docname,  # the document currently being parsed
                 field_entry.label,
                 field_entry.alias,
             )
@@ -330,9 +331,10 @@ class KitbashModelDirective(SphinxDirective):
                     else field_entry.alias
                 )
 
+                # Add cross-referencing details to Sphinx's domain data
                 if state:
                     self.env.app.env.domaindata["std"]["labels"][field_entry.label] = (
-                        self.env.docname,
+                        self.env.docname,  # the document currently being parsed
                         field_entry.label,
                         field_entry.alias,
                     )

--- a/tests/integration/example/index.rst
+++ b/tests/integration/example/index.rst
@@ -2,4 +2,11 @@
 Fields
 ======
 
+:ref:`Automatic label <index-test>`
+
 .. kitbash-field:: example.project.MockModel mock_field
+
+:ref:`Manual label <cool-beans>`
+
+.. kitbash-field:: example.project.MockModel mock_field
+    :label: cool-beans

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -178,6 +178,32 @@ def test_kitbash_field(fake_field_directive: FakeFieldDirective):
     assert str(expected) == str(actual)
 
 
+def test_fake(fake_field_directive: FakeFieldDirective):
+    """Test for KitbashFieldDirective."""
+
+    expected = nodes.section(ids=["test"])
+    expected["classes"].append("kitbash-entry")
+
+    field_entry = """\
+
+    .. _label:
+
+    test
+    ----
+
+    this is how Sphinx renders refs.
+
+    """
+
+    field_entry = strip_whitespace(field_entry)
+    expected += publish_doctree(field_entry).children
+    actual = fake_field_directive.run()[0]
+
+    print(f"\n\n{expected}\n\n")
+
+    assert str(expected) == str(actual)
+
+
 @pytest.mark.parametrize(
     ("fake_field_directive", "title_text"),
     [
@@ -308,12 +334,12 @@ def test_kitbash_field_label_option(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
     """Test for the skip-examples option in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["bad-example"])
+    expected = nodes.section(ids=["bad_example"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="bad_example")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "bad-example"
+    target_node["refid"] = "bad_example"
     expected += target_node
 
     field_entry = """\
@@ -343,12 +369,12 @@ def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_enum(fake_field_directive: FakeFieldDirective):
     """Test for the KitbashFieldDirective when passed an enum field."""
 
-    expected = nodes.section(ids=["enum-field"])
+    expected = nodes.section(ids=["enum_field"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_field")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "enum-field"
+    target_node["refid"] = "enum_field"
     expected += target_node
 
     field_entry = """\
@@ -383,12 +409,12 @@ def test_kitbash_field_enum(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_union_type(fake_field_directive: FakeFieldDirective):
     """Test for the KitbashFieldDirective when passed a types.UnionType field."""
 
-    expected = nodes.section(ids=["uniontype-field"])
+    expected = nodes.section(ids=["uniontype_field"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="uniontype_field")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "uniontype-field"
+    target_node["refid"] = "uniontype_field"
     expected += target_node
 
     field_entry = """\
@@ -418,12 +444,12 @@ def test_kitbash_field_union_type(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
     """Test for the KitbashFieldDirective when passed an enum UnionType field."""
 
-    expected = nodes.section(ids=["enum-uniontype"])
+    expected = nodes.section(ids=["enum_uniontype"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_uniontype")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "enum-uniontype"
+    target_node["refid"] = "enum_uniontype"
     expected += target_node
 
     field_entry = """\
@@ -459,12 +485,12 @@ def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_typing_union(fake_field_directive: FakeFieldDirective):
     """Test for KitbashFieldDirective when passed a typing.Union field."""
 
-    expected = nodes.section(ids=["typing-union"])
+    expected = nodes.section(ids=["typing_union"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="typing_union")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "typing-union"
+    target_node["refid"] = "typing_union"
     expected += target_node
 
     field_entry = """\

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -151,6 +151,9 @@ def test_kitbash_field(fake_field_directive: FakeFieldDirective):
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "test"
+    expected += target_node
 
     field_entry = """\
 
@@ -196,6 +199,9 @@ def test_kitbash_field_name_options(
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text=title_text)
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "test"
+    expected += target_node
 
     field_entry = """\
 
@@ -230,6 +236,9 @@ def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "test"
+    expected += target_node
 
     field_entry = """\
 
@@ -264,6 +273,9 @@ def test_kitbash_field_label_option(fake_field_directive: FakeFieldDirective):
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "custom-label"
+    expected += target_node
 
     field_entry = """\
 
@@ -300,6 +312,9 @@ def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="bad_example")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "bad-example"
+    expected += target_node
 
     field_entry = """\
 
@@ -332,6 +347,9 @@ def test_kitbash_field_enum(fake_field_directive: FakeFieldDirective):
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_field")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "enum-field"
+    expected += target_node
 
     field_entry = """\
 
@@ -369,6 +387,9 @@ def test_kitbash_field_union_type(fake_field_directive: FakeFieldDirective):
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="uniontype_field")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "uniontype-field"
+    expected += target_node
 
     field_entry = """\
 
@@ -401,6 +422,9 @@ def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_uniontype")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "enum-uniontype"
+    expected += target_node
 
     field_entry = """\
 
@@ -439,6 +463,9 @@ def test_kitbash_field_typing_union(fake_field_directive: FakeFieldDirective):
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="typing_union")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "typing-union"
+    expected += target_node
 
     field_entry = """\
 

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -178,32 +178,6 @@ def test_kitbash_field(fake_field_directive: FakeFieldDirective):
     assert str(expected) == str(actual)
 
 
-def test_fake(fake_field_directive: FakeFieldDirective):
-    """Test for KitbashFieldDirective."""
-
-    expected = nodes.section(ids=["test"])
-    expected["classes"].append("kitbash-entry")
-
-    field_entry = """\
-
-    .. _label:
-
-    test
-    ----
-
-    this is how Sphinx renders refs.
-
-    """
-
-    field_entry = strip_whitespace(field_entry)
-    expected += publish_doctree(field_entry).children
-    actual = fake_field_directive.run()[0]
-
-    print(f"\n\n{expected}\n\n")
-
-    assert str(expected) == str(actual)
-
-
 @pytest.mark.parametrize(
     ("fake_field_directive", "title_text"),
     [

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -179,9 +179,11 @@ def test_kitbash_field(fake_field_directive: FakeFieldDirective):
     ("fake_field_directive", "title_text"),
     [
         pytest.param(
-            {"options": {"prepend-name": "app"}}, "app.test", id="prepend-name"
+            {"options": {"prepend-name": "prefix"}}, "prefix.test", id="prepend-name"
         ),
-        pytest.param({"options": {"append-name": "app"}}, "test.app", id="append-name"),
+        pytest.param(
+            {"options": {"append-name": "suffix"}}, "test.suffix", id="append-name"
+        ),
     ],
     indirect=["fake_field_directive"],
 )
@@ -190,7 +192,7 @@ def test_kitbash_field_name_options(
 ):
     """Test for the -name options in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=[title_text])
+    expected = nodes.section(ids=["test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text=title_text)
     expected += title_node
@@ -253,6 +255,40 @@ def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
 
 
 @pytest.mark.parametrize(
+    "fake_field_directive", [{"options": {"label": "custom-label"}}], indirect=True
+)
+def test_kitbash_field_label_option(fake_field_directive: FakeFieldDirective):
+    """Test for the override-type option in KitbashFieldDirective."""
+
+    expected = nodes.section(ids=["custom-label"])
+    expected["classes"].append("kitbash-entry")
+    title_node = nodes.title(text="test")
+    expected += title_node
+
+    field_entry = """\
+
+    .. important::
+
+        Deprecated. ew.
+
+    **Type**
+
+    ``int``
+
+    **Description**
+
+    description
+
+    """
+
+    field_entry = strip_whitespace(field_entry)
+    expected += publish_doctree(field_entry).children
+    actual = fake_field_directive.run()[0]
+
+    assert str(expected) == str(actual)
+
+
+@pytest.mark.parametrize(
     "fake_field_directive",
     [{"model_field": "bad_example", "options": {"skip-examples": None}}],
     indirect=True,
@@ -260,7 +296,7 @@ def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
     """Test for the skip-examples option in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["bad_example"])
+    expected = nodes.section(ids=["bad-example"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="bad_example")
     expected += title_node
@@ -292,7 +328,7 @@ def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_enum(fake_field_directive: FakeFieldDirective):
     """Test for the KitbashFieldDirective when passed an enum field."""
 
-    expected = nodes.section(ids=["enum_field"])
+    expected = nodes.section(ids=["enum-field"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_field")
     expected += title_node
@@ -329,7 +365,7 @@ def test_kitbash_field_enum(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_union_type(fake_field_directive: FakeFieldDirective):
     """Test for the KitbashFieldDirective when passed a types.UnionType field."""
 
-    expected = nodes.section(ids=["uniontype_field"])
+    expected = nodes.section(ids=["uniontype-field"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="uniontype_field")
     expected += title_node
@@ -361,7 +397,7 @@ def test_kitbash_field_union_type(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
     """Test for the KitbashFieldDirective when passed an enum UnionType field."""
 
-    expected = nodes.section(ids=["enum_uniontype"])
+    expected = nodes.section(ids=["enum-uniontype"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_uniontype")
     expected += title_node
@@ -399,7 +435,7 @@ def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_typing_union(fake_field_directive: FakeFieldDirective):
     """Test for KitbashFieldDirective when passed a typing.Union field."""
 
-    expected = nodes.section(ids=["typing_union"])
+    expected = nodes.section(ids=["typing-union"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="typing_union")
     expected += title_node

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -147,7 +147,9 @@ def test_kitbash_field_invalid(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field(fake_field_directive: FakeFieldDirective):
     """Test for KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["test"])
+    # The IDs are duplicated because the test directives have no state.
+    # In actual usage, the second ID will always be prefixed with the filename.
+    expected = nodes.section(ids=["test", "test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
     expected += title_node
@@ -179,25 +181,51 @@ def test_kitbash_field(fake_field_directive: FakeFieldDirective):
 
 
 @pytest.mark.parametrize(
-    ("fake_field_directive", "title_text"),
-    [
-        pytest.param(
-            {"options": {"prepend-name": "prefix"}}, "prefix.test", id="prepend-name"
-        ),
-        pytest.param(
-            {"options": {"append-name": "suffix"}}, "test.suffix", id="append-name"
-        ),
-    ],
-    indirect=["fake_field_directive"],
+    "fake_field_directive", [{"options": {"prepend-name": "prefix"}}], indirect=True
 )
-def test_kitbash_field_name_options(
-    fake_field_directive: FakeFieldDirective, title_text: str
-):
+def test_kitbash_field_prepend_name(fake_field_directive: FakeFieldDirective):
     """Test for the -name options in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["test"])
+    expected = nodes.section(ids=["prefix.test", "test"])
     expected["classes"].append("kitbash-entry")
-    title_node = nodes.title(text=title_text)
+    title_node = nodes.title(text="prefix.test")
+    expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "test"
+    expected += target_node
+
+    field_entry = """\
+
+    .. important::
+
+        Deprecated. ew.
+
+    **Type**
+
+    ``int``
+
+    **Description**
+
+    description
+
+    """
+
+    field_entry = strip_whitespace(field_entry)
+    expected += publish_doctree(field_entry).children
+    actual = fake_field_directive.run()[0]
+
+    assert str(expected) == str(actual)
+
+
+@pytest.mark.parametrize(
+    "fake_field_directive", [{"options": {"append-name": "suffix"}}], indirect=True
+)
+def test_kitbash_field_append_name(fake_field_directive: FakeFieldDirective):
+    """Test for the -name options in KitbashFieldDirective."""
+
+    expected = nodes.section(ids=["test.suffix", "test"])
+    expected["classes"].append("kitbash-entry")
+    title_node = nodes.title(text="test.suffix")
     expected += title_node
     target_node = nodes.target()
     target_node["refid"] = "test"
@@ -232,7 +260,7 @@ def test_kitbash_field_name_options(
 def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
     """Test for the override-type option in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["test"])
+    expected = nodes.section(ids=["test", "test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
     expected += title_node
@@ -269,7 +297,7 @@ def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_label_option(fake_field_directive: FakeFieldDirective):
     """Test for the override-type option in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["custom-label"])
+    expected = nodes.section(ids=["test", "custom-label"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
     expected += title_node
@@ -308,7 +336,7 @@ def test_kitbash_field_label_option(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
     """Test for the skip-examples option in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["bad_example"])
+    expected = nodes.section(ids=["bad_example", "bad_example"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="bad_example")
     expected += title_node
@@ -343,7 +371,7 @@ def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_enum(fake_field_directive: FakeFieldDirective):
     """Test for the KitbashFieldDirective when passed an enum field."""
 
-    expected = nodes.section(ids=["enum_field"])
+    expected = nodes.section(ids=["enum_field", "enum_field"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_field")
     expected += title_node
@@ -383,7 +411,7 @@ def test_kitbash_field_enum(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_union_type(fake_field_directive: FakeFieldDirective):
     """Test for the KitbashFieldDirective when passed a types.UnionType field."""
 
-    expected = nodes.section(ids=["uniontype_field"])
+    expected = nodes.section(ids=["uniontype_field", "uniontype_field"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="uniontype_field")
     expected += title_node
@@ -418,7 +446,7 @@ def test_kitbash_field_union_type(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
     """Test for the KitbashFieldDirective when passed an enum UnionType field."""
 
-    expected = nodes.section(ids=["enum_uniontype"])
+    expected = nodes.section(ids=["enum_uniontype", "enum_uniontype"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_uniontype")
     expected += title_node
@@ -459,7 +487,7 @@ def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
 def test_kitbash_field_typing_union(fake_field_directive: FakeFieldDirective):
     """Test for KitbashFieldDirective when passed a typing.Union field."""
 
-    expected = nodes.section(ids=["typing_union"])
+    expected = nodes.section(ids=["typing_union", "typing_union"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="typing_union")
     expected += title_node

--- a/tests/unit/test_kitbash_model.py
+++ b/tests/unit/test_kitbash_model.py
@@ -235,12 +235,12 @@ def test_kitbash_model(fake_model_directive):
 
     expected = list(publish_doctree(MockModel.__doc__).children)
 
-    uniontype_section = build_section_node("uniontype-field", "uniontype_field")
+    uniontype_section = build_section_node("uniontype_field", "uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum-field", "enum_field")
+    enum_section = build_section_node("enum_field", "enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -248,7 +248,7 @@ def test_kitbash_model(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = build_section_node("enum-uniontype", "enum_uniontype")
+    enum_uniontype_section = build_section_node("enum_uniontype", "enum_uniontype")
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
     enum_uniontype_value_container = nodes.container()
@@ -256,7 +256,7 @@ def test_kitbash_model(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = build_section_node("typing-union", "typing_union")
+    typing_union_section = build_section_node("typing_union", "typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -283,12 +283,12 @@ def test_kitbash_model_skip_description(fake_model_directive):
 
     expected = []
 
-    uniontype_section = build_section_node("uniontype-field", "uniontype_field")
+    uniontype_section = build_section_node("uniontype_field", "uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum-field", "enum_field")
+    enum_section = build_section_node("enum_field", "enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -296,7 +296,7 @@ def test_kitbash_model_skip_description(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = build_section_node("enum-uniontype", "enum_uniontype")
+    enum_uniontype_section = build_section_node("enum_uniontype", "enum_uniontype")
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
 
@@ -305,7 +305,7 @@ def test_kitbash_model_skip_description(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = build_section_node("typing-union", "typing_union")
+    typing_union_section = build_section_node("typing_union", "typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -324,12 +324,12 @@ def test_kitbash_model_content(fake_model_directive):
 
     expected = list(publish_doctree("``Test content``").children)
 
-    uniontype_section = build_section_node("uniontype-field", "uniontype_field")
+    uniontype_section = build_section_node("uniontype_field", "uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum-field", "enum_field")
+    enum_section = build_section_node("enum_field", "enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -337,7 +337,7 @@ def test_kitbash_model_content(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = build_section_node("enum-uniontype", "enum_uniontype")
+    enum_uniontype_section = build_section_node("enum_uniontype", "enum_uniontype")
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
     enum_uniontype_value_container = nodes.container()
@@ -345,7 +345,7 @@ def test_kitbash_model_content(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = build_section_node("typing-union", "typing_union")
+    typing_union_section = build_section_node("typing_union", "typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -377,12 +377,12 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     mock_field_section += publish_doctree(mock_field_rst).children
     expected.append(mock_field_section)
 
-    uniontype_section = build_section_node("uniontype-field", "uniontype_field")
+    uniontype_section = build_section_node("uniontype_field", "uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum-field", "enum_field")
+    enum_section = build_section_node("enum_field", "enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -390,7 +390,7 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = build_section_node("enum-uniontype", "enum_uniontype")
+    enum_uniontype_section = build_section_node("enum_uniontype", "enum_uniontype")
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
     enum_uniontype_value_container = nodes.container()
@@ -398,7 +398,7 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = build_section_node("typing-union", "typing_union")
+    typing_union_section = build_section_node("typing_union", "typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -427,13 +427,13 @@ def test_kitbash_model_name_options(fake_model_directive):
     expected = list(publish_doctree("this is the model's docstring").children)
 
     uniontype_section = build_section_node(
-        "uniontype-field", "prefix.uniontype_field.suffix"
+        "uniontype_field", "prefix.uniontype_field.suffix"
     )
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum-field", "prefix.enum_field.suffix")
+    enum_section = build_section_node("enum_field", "prefix.enum_field.suffix")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -442,7 +442,7 @@ def test_kitbash_model_name_options(fake_model_directive):
     expected.append(enum_section)
 
     enum_uniontype_section = build_section_node(
-        "enum-uniontype", "prefix.enum_uniontype.suffix"
+        "enum_uniontype", "prefix.enum_uniontype.suffix"
     )
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
@@ -452,7 +452,7 @@ def test_kitbash_model_name_options(fake_model_directive):
     expected.append(enum_uniontype_section)
 
     typing_union_section = build_section_node(
-        "typing-union", "prefix.typing_union.suffix"
+        "typing_union", "prefix.typing_union.suffix"
     )
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children

--- a/tests/unit/test_kitbash_model.py
+++ b/tests/unit/test_kitbash_model.py
@@ -202,7 +202,6 @@ def build_section_node(node_id: str, title: str) -> nodes.section:
 
     Args:
         node_id (str): The ref ID (label) for the field.
-
         title (str): The title node content (heading) for the field
 
     Returns:
@@ -210,7 +209,7 @@ def build_section_node(node_id: str, title: str) -> nodes.section:
 
     """
 
-    section_node = nodes.section(ids=[node_id])
+    section_node = nodes.section(ids=[title, node_id])
     section_node["classes"].append("kitbash-entry")
     title_node = nodes.title(text=title)
     section_node += title_node

--- a/tests/unit/test_kitbash_model.py
+++ b/tests/unit/test_kitbash_model.py
@@ -98,7 +98,7 @@ LIST_TABLE_RST = """
 .. list-table::
     :header-rows: 1
 
-    * - Values
+    * - Value
       - Description
     * - ``value1``
       - The first value.
@@ -118,7 +118,6 @@ TEST_TYPE = Annotated[
     pydantic.BeforeValidator(validator),
     pydantic.Field(
         description="This is a typing.Union",
-        examples=["str1", "str2", "str3"],
     ),
 ]
 
@@ -212,7 +211,7 @@ def test_kitbash_model(fake_model_directive):
 
     expected = list(publish_doctree(MockModel.__doc__).children)
 
-    uniontype_section = nodes.section(ids=["uniontype_field"])
+    uniontype_section = nodes.section(ids=["uniontype-field"])
     uniontype_section["classes"].append("kitbash-entry")
     uniontype_title = nodes.title(text="uniontype_field")
     uniontype_section += uniontype_title
@@ -221,7 +220,7 @@ def test_kitbash_model(fake_model_directive):
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["enum_field"])
+    enum_section = nodes.section(ids=["enum-field"])
     enum_section["classes"].append("kitbash-entry")
     enum_title = nodes.title(text="enum_field")
     enum_section += enum_title
@@ -234,7 +233,7 @@ def test_kitbash_model(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["enum_uniontype"])
+    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
     enum_uniontype_section["classes"].append("kitbash-entry")
     enum_uniontype_title = nodes.title(text="enum_uniontype")
     enum_uniontype_section += enum_uniontype_title
@@ -247,7 +246,7 @@ def test_kitbash_model(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["typing_union"])
+    typing_union_section = nodes.section(ids=["typing-union"])
     typing_union_section["classes"].append("kitbash-entry")
     typing_union_title = nodes.title(text="typing_union")
     typing_union_section += typing_union_title
@@ -258,7 +257,8 @@ def test_kitbash_model(fake_model_directive):
 
     actual = fake_model_directive.run()
 
-    assert str(expected) == str(actual)
+    for i, node in enumerate(expected):
+        assert str(node) == str(actual[i])
 
 
 @pytest.mark.parametrize(
@@ -277,7 +277,7 @@ def test_kitbash_model_skip_description(fake_model_directive):
 
     expected = []
 
-    uniontype_section = nodes.section(ids=["uniontype_field"])
+    uniontype_section = nodes.section(ids=["uniontype-field"])
     uniontype_section["classes"].append("kitbash-entry")
     uniontype_title = nodes.title(text="uniontype_field")
     uniontype_section += uniontype_title
@@ -286,7 +286,7 @@ def test_kitbash_model_skip_description(fake_model_directive):
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["enum_field"])
+    enum_section = nodes.section(ids=["enum-field"])
     enum_section["classes"].append("kitbash-entry")
     enum_title = nodes.title(text="enum_field")
     enum_section += enum_title
@@ -299,7 +299,7 @@ def test_kitbash_model_skip_description(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["enum_uniontype"])
+    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
     enum_uniontype_section["classes"].append("kitbash-entry")
     enum_uniontype_title = nodes.title(text="enum_uniontype")
     enum_uniontype_section += enum_uniontype_title
@@ -312,7 +312,7 @@ def test_kitbash_model_skip_description(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["typing_union"])
+    typing_union_section = nodes.section(ids=["typing-union"])
     typing_union_section["classes"].append("kitbash-entry")
     typing_union_title = nodes.title(text="typing_union")
     typing_union_section += typing_union_title
@@ -323,7 +323,8 @@ def test_kitbash_model_skip_description(fake_model_directive):
 
     actual = fake_model_directive.run()
 
-    assert str(expected) == str(actual)
+    for i, node in enumerate(expected):
+        assert str(node) == str(actual[i])
 
 
 @pytest.mark.parametrize(
@@ -334,7 +335,7 @@ def test_kitbash_model_content(fake_model_directive):
 
     expected = list(publish_doctree("``Test content``").children)
 
-    uniontype_section = nodes.section(ids=["uniontype_field"])
+    uniontype_section = nodes.section(ids=["uniontype-field"])
     uniontype_section["classes"].append("kitbash-entry")
     uniontype_title = nodes.title(text="uniontype_field")
     uniontype_section += uniontype_title
@@ -343,7 +344,7 @@ def test_kitbash_model_content(fake_model_directive):
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["enum_field"])
+    enum_section = nodes.section(ids=["enum-field"])
     enum_section["classes"].append("kitbash-entry")
     enum_title = nodes.title(text="enum_field")
     enum_section += enum_title
@@ -356,7 +357,7 @@ def test_kitbash_model_content(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["enum_uniontype"])
+    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
     enum_uniontype_section["classes"].append("kitbash-entry")
     enum_uniontype_title = nodes.title(text="enum_uniontype")
     enum_uniontype_section += enum_uniontype_title
@@ -369,7 +370,7 @@ def test_kitbash_model_content(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["typing_union"])
+    typing_union_section = nodes.section(ids=["typing-union"])
     typing_union_section["classes"].append("kitbash-entry")
     typing_union_title = nodes.title(text="typing_union")
     typing_union_section += typing_union_title
@@ -380,7 +381,8 @@ def test_kitbash_model_content(fake_model_directive):
 
     actual = fake_model_directive.run()
 
-    assert str(expected) == str(actual)
+    for i, node in enumerate(expected):
+        assert str(node) == str(actual[i])
 
 
 @pytest.mark.parametrize(
@@ -408,7 +410,7 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     mock_field_section += publish_doctree(mock_field_rst).children
     expected.append(mock_field_section)
 
-    uniontype_section = nodes.section(ids=["uniontype_field"])
+    uniontype_section = nodes.section(ids=["uniontype-field"])
     uniontype_section["classes"].append("kitbash-entry")
     uniontype_title = nodes.title(text="uniontype_field")
     uniontype_section += uniontype_title
@@ -417,7 +419,7 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["enum_field"])
+    enum_section = nodes.section(ids=["enum-field"])
     enum_section["classes"].append("kitbash-entry")
     enum_title = nodes.title(text="enum_field")
     enum_section += enum_title
@@ -430,7 +432,7 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["enum_uniontype"])
+    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
     enum_uniontype_section["classes"].append("kitbash-entry")
     enum_uniontype_title = nodes.title(text="enum_uniontype")
     enum_uniontype_section += enum_uniontype_title
@@ -443,7 +445,7 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["typing_union"])
+    typing_union_section = nodes.section(ids=["typing-union"])
     typing_union_section["classes"].append("kitbash-entry")
     typing_union_title = nodes.title(text="typing_union")
     typing_union_section += typing_union_title
@@ -454,7 +456,8 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
 
     actual = fake_model_directive.run()
 
-    assert str(expected) == str(actual)
+    for i, node in enumerate(expected):
+        assert str(node) == str(actual[i])
 
 
 @pytest.mark.parametrize(
@@ -474,7 +477,7 @@ def test_kitbash_model_name_options(fake_model_directive):
 
     expected = list(publish_doctree("this is the model's docstring").children)
 
-    uniontype_section = nodes.section(ids=["prefix.uniontype_field.suffix"])
+    uniontype_section = nodes.section(ids=["uniontype-field"])
     uniontype_section["classes"].append("kitbash-entry")
     uniontype_title = nodes.title(text="prefix.uniontype_field.suffix")
     uniontype_section += uniontype_title
@@ -483,7 +486,7 @@ def test_kitbash_model_name_options(fake_model_directive):
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["prefix.enum_field.suffix"])
+    enum_section = nodes.section(ids=["enum-field"])
     enum_section["classes"].append("kitbash-entry")
     enum_title = nodes.title(text="prefix.enum_field.suffix")
     enum_section += enum_title
@@ -496,7 +499,7 @@ def test_kitbash_model_name_options(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["prefix.enum_uniontype.suffix"])
+    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
     enum_uniontype_section["classes"].append("kitbash-entry")
     enum_uniontype_title = nodes.title(text="prefix.enum_uniontype.suffix")
     enum_uniontype_section += enum_uniontype_title
@@ -509,7 +512,7 @@ def test_kitbash_model_name_options(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["prefix.typing_union.suffix"])
+    typing_union_section = nodes.section(ids=["typing-union"])
     typing_union_section["classes"].append("kitbash-entry")
     typing_union_title = nodes.title(text="prefix.typing_union.suffix")
     typing_union_section += typing_union_title
@@ -520,4 +523,5 @@ def test_kitbash_model_name_options(fake_model_directive):
 
     actual = fake_model_directive.run()
 
-    assert str(expected) == str(actual)
+    for i, node in enumerate(expected):
+        assert str(node) == str(actual[i])

--- a/tests/unit/test_kitbash_model.py
+++ b/tests/unit/test_kitbash_model.py
@@ -197,6 +197,30 @@ def fake_model_directive(request: pytest.FixtureRequest) -> FakeModelDirective:
     )
 
 
+def build_section_node(node_id: str, title: str) -> nodes.section:
+    """Create a section node containing all of the information for a single field.
+
+    Args:
+        node_id (str): The ref ID (label) for the field.
+
+        title (str): The title node content (heading) for the field
+
+    Returns:
+        nodes.section: A section containing well-formed nodes for the field.
+
+    """
+
+    section_node = nodes.section(ids=[node_id])
+    section_node["classes"].append("kitbash-entry")
+    title_node = nodes.title(text=title)
+    section_node += title_node
+    target_node = nodes.target()
+    target_node["refid"] = node_id
+    section_node += target_node
+
+    return section_node
+
+
 @pytest.mark.parametrize(
     "fake_model_directive", [{"model": ".OopsNoModel"}], indirect=True
 )
@@ -211,46 +235,28 @@ def test_kitbash_model(fake_model_directive):
 
     expected = list(publish_doctree(MockModel.__doc__).children)
 
-    uniontype_section = nodes.section(ids=["uniontype-field"])
-    uniontype_section["classes"].append("kitbash-entry")
-    uniontype_title = nodes.title(text="uniontype_field")
-    uniontype_section += uniontype_title
-
+    uniontype_section = build_section_node("uniontype-field", "uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["enum-field"])
-    enum_section["classes"].append("kitbash-entry")
-    enum_title = nodes.title(text="enum_field")
-    enum_section += enum_title
-
+    enum_section = build_section_node("enum-field", "enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
-
     enum_value_container = nodes.container()
     enum_value_container += publish_doctree(LIST_TABLE_RST).children
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
-    enum_uniontype_section["classes"].append("kitbash-entry")
-    enum_uniontype_title = nodes.title(text="enum_uniontype")
-    enum_uniontype_section += enum_uniontype_title
-
+    enum_uniontype_section = build_section_node("enum-uniontype", "enum_uniontype")
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
-
     enum_uniontype_value_container = nodes.container()
     enum_uniontype_value_container += publish_doctree(LIST_TABLE_RST).children
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["typing-union"])
-    typing_union_section["classes"].append("kitbash-entry")
-    typing_union_title = nodes.title(text="typing_union")
-    typing_union_section += typing_union_title
-
+    typing_union_section = build_section_node("typing-union", "typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -277,33 +283,20 @@ def test_kitbash_model_skip_description(fake_model_directive):
 
     expected = []
 
-    uniontype_section = nodes.section(ids=["uniontype-field"])
-    uniontype_section["classes"].append("kitbash-entry")
-    uniontype_title = nodes.title(text="uniontype_field")
-    uniontype_section += uniontype_title
-
+    uniontype_section = build_section_node("uniontype-field", "uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["enum-field"])
-    enum_section["classes"].append("kitbash-entry")
-    enum_title = nodes.title(text="enum_field")
-    enum_section += enum_title
-
+    enum_section = build_section_node("enum-field", "enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
-
     enum_value_container = nodes.container()
     enum_value_container += publish_doctree(LIST_TABLE_RST).children
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
-    enum_uniontype_section["classes"].append("kitbash-entry")
-    enum_uniontype_title = nodes.title(text="enum_uniontype")
-    enum_uniontype_section += enum_uniontype_title
-
+    enum_uniontype_section = build_section_node("enum-uniontype", "enum_uniontype")
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
 
@@ -312,11 +305,7 @@ def test_kitbash_model_skip_description(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["typing-union"])
-    typing_union_section["classes"].append("kitbash-entry")
-    typing_union_title = nodes.title(text="typing_union")
-    typing_union_section += typing_union_title
-
+    typing_union_section = build_section_node("typing-union", "typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -335,46 +324,28 @@ def test_kitbash_model_content(fake_model_directive):
 
     expected = list(publish_doctree("``Test content``").children)
 
-    uniontype_section = nodes.section(ids=["uniontype-field"])
-    uniontype_section["classes"].append("kitbash-entry")
-    uniontype_title = nodes.title(text="uniontype_field")
-    uniontype_section += uniontype_title
-
+    uniontype_section = build_section_node("uniontype-field", "uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["enum-field"])
-    enum_section["classes"].append("kitbash-entry")
-    enum_title = nodes.title(text="enum_field")
-    enum_section += enum_title
-
+    enum_section = build_section_node("enum-field", "enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
-
     enum_value_container = nodes.container()
     enum_value_container += publish_doctree(LIST_TABLE_RST).children
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
-    enum_uniontype_section["classes"].append("kitbash-entry")
-    enum_uniontype_title = nodes.title(text="enum_uniontype")
-    enum_uniontype_section += enum_uniontype_title
-
+    enum_uniontype_section = build_section_node("enum-uniontype", "enum_uniontype")
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
-
     enum_uniontype_value_container = nodes.container()
     enum_uniontype_value_container += publish_doctree(LIST_TABLE_RST).children
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["typing-union"])
-    typing_union_section["classes"].append("kitbash-entry")
-    typing_union_title = nodes.title(text="typing_union")
-    typing_union_section += typing_union_title
-
+    typing_union_section = build_section_node("typing-union", "typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -401,55 +372,33 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
 
     expected = list(publish_doctree("this is the model's docstring").children)
 
-    mock_field_section = nodes.section(ids=["test"])
-    mock_field_section["classes"].append("kitbash-entry")
-    mock_field_title = nodes.title(text="test")
-    mock_field_section += mock_field_title
-
+    mock_field_section = build_section_node("test", "test")
     mock_field_rst = strip_whitespace(MOCK_FIELD_RST)
     mock_field_section += publish_doctree(mock_field_rst).children
     expected.append(mock_field_section)
 
-    uniontype_section = nodes.section(ids=["uniontype-field"])
-    uniontype_section["classes"].append("kitbash-entry")
-    uniontype_title = nodes.title(text="uniontype_field")
-    uniontype_section += uniontype_title
-
+    uniontype_section = build_section_node("uniontype-field", "uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["enum-field"])
-    enum_section["classes"].append("kitbash-entry")
-    enum_title = nodes.title(text="enum_field")
-    enum_section += enum_title
-
+    enum_section = build_section_node("enum-field", "enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
-
     enum_value_container = nodes.container()
     enum_value_container += publish_doctree(LIST_TABLE_RST).children
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
-    enum_uniontype_section["classes"].append("kitbash-entry")
-    enum_uniontype_title = nodes.title(text="enum_uniontype")
-    enum_uniontype_section += enum_uniontype_title
-
+    enum_uniontype_section = build_section_node("enum-uniontype", "enum_uniontype")
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
-
     enum_uniontype_value_container = nodes.container()
     enum_uniontype_value_container += publish_doctree(LIST_TABLE_RST).children
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["typing-union"])
-    typing_union_section["classes"].append("kitbash-entry")
-    typing_union_title = nodes.title(text="typing_union")
-    typing_union_section += typing_union_title
-
+    typing_union_section = build_section_node("typing-union", "typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -477,46 +426,34 @@ def test_kitbash_model_name_options(fake_model_directive):
 
     expected = list(publish_doctree("this is the model's docstring").children)
 
-    uniontype_section = nodes.section(ids=["uniontype-field"])
-    uniontype_section["classes"].append("kitbash-entry")
-    uniontype_title = nodes.title(text="prefix.uniontype_field.suffix")
-    uniontype_section += uniontype_title
-
+    uniontype_section = build_section_node(
+        "uniontype-field", "prefix.uniontype_field.suffix"
+    )
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = nodes.section(ids=["enum-field"])
-    enum_section["classes"].append("kitbash-entry")
-    enum_title = nodes.title(text="prefix.enum_field.suffix")
-    enum_section += enum_title
-
+    enum_section = build_section_node("enum-field", "prefix.enum_field.suffix")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
-
     enum_value_container = nodes.container()
     enum_value_container += publish_doctree(LIST_TABLE_RST).children
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = nodes.section(ids=["enum-uniontype"])
-    enum_uniontype_section["classes"].append("kitbash-entry")
-    enum_uniontype_title = nodes.title(text="prefix.enum_uniontype.suffix")
-    enum_uniontype_section += enum_uniontype_title
-
+    enum_uniontype_section = build_section_node(
+        "enum-uniontype", "prefix.enum_uniontype.suffix"
+    )
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
-
     enum_uniontype_value_container = nodes.container()
     enum_uniontype_value_container += publish_doctree(LIST_TABLE_RST).children
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = nodes.section(ids=["typing-union"])
-    typing_union_section["classes"].append("kitbash-entry")
-    typing_union_title = nodes.title(text="prefix.typing_union.suffix")
-    typing_union_section += typing_union_title
-
+    typing_union_section = build_section_node(
+        "typing-union", "prefix.typing_union.suffix"
+    )
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)

--- a/tests/unit/test_supporting_functions.py
+++ b/tests/unit/test_supporting_functions.py
@@ -228,10 +228,14 @@ def test_create_field_node():
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="key-name")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "key-name"
+    expected += target_node
     expected += publish_doctree(KEY_ENTRY_RST).children
 
     test_entry = FieldEntry("key-name")
     test_entry.alias = "key-name"
+    test_entry.label = "key-name"
     test_entry.deprecation_warning = "Don't use this."
     test_entry.field_type = "str"
     test_entry.description = "This is the key description"
@@ -252,10 +256,14 @@ def test_create_field_node_literal_list():
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="key-name")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "key-name"
+    expected += target_node
     expected += publish_doctree(LITERAL_LIST_ENTRY_RST).children
 
     test_entry = FieldEntry("key-name")
     test_entry.alias = "key-name"
+    test_entry.label = "key-name"
     test_entry.deprecation_warning = "Don't use this."
     test_entry.field_type = "Literal['one', 'two', 'three']"
     test_entry.description = "This is the key description"
@@ -272,6 +280,9 @@ def test_create_minimal_field_node():
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="key-name")
     expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "key-name"
+    expected += target_node
 
     test_entry = FieldEntry("key-name")
 

--- a/tests/unit/test_supporting_functions.py
+++ b/tests/unit/test_supporting_functions.py
@@ -224,7 +224,7 @@ def test_create_field_node():
     """Test for create_field_node."""
 
     # need to set up section node manually
-    expected = nodes.section(ids=["key-name"])
+    expected = nodes.section(ids=["key-name", "key-name"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="key-name")
     expected += title_node
@@ -252,7 +252,7 @@ def test_create_field_node_literal_list():
     """Test for create_field_node with a FieldEntry of type Literal[]."""
 
     # need to set up section node manually
-    expected = nodes.section(ids=["key-name"])
+    expected = nodes.section(ids=["key-name", "key-name"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="key-name")
     expected += title_node
@@ -276,7 +276,7 @@ def test_create_minimal_field_node():
     """Test for create_field_node with a minimal set of attributes."""
 
     # need to set up section node manually
-    expected = nodes.section(ids=["key-name"])
+    expected = nodes.section(ids=["key-name", "key-name"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="key-name")
     expected += title_node


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X]  Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Resolves https://github.com/canonical/pydantic-kitbash/issues/47

* Add automatic `<filename>-<key-name>` labels
* Add a `:label:` option to name labels manually
* Improve accuracy of `kitbash-model` tests by list items one-by-one

For this to work, the `id` of the section nodes must match the label rather than the key name.
