### PR TITLE
test: preserve integration test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ coverage.xml
 .pytest_cache/
 .results.*.xml
 
+# Integration test output
+.test_output
+
 # Translations
 *.mo
 *.pot

--- a/common.mk
+++ b/common.mk
@@ -76,7 +76,7 @@ endif
 .PHONY: clean
 clean:  ## Clean up the development environment
 	uv tool run pyclean .
-	rm -rf dist/ build/ docs/_build/ *.snap .coverage*
+	rm -rf dist/ build/ docs/_build/ .test_output/ *.snap .coverage*
 
 .PHONY: autoformat
 autoformat: format  # Hidden alias for 'format'

--- a/tests/integration/test_pydantic_kitbash.py
+++ b/tests/integration/test_pydantic_kitbash.py
@@ -30,7 +30,7 @@ def example_project(request) -> Path:
     # Copy the project into the test's own temporary dir, to avoid clobbering
     # the sources.
     target_dir = Path().resolve() / "example"
-    shutil.copytree(example_dir, target_dir)
+    shutil.copytree(example_dir, target_dir, dirs_exist_ok=True)
 
     return target_dir
 
@@ -43,7 +43,12 @@ def test_pydantic_kitbash_integration(example_project):
     )
 
     index = build_dir / "index.html"
+
+    # Rename the test output to something more meaningful
+    shutil.copytree(build_dir, build_dir.parents[1] / ".test_output")
+
     soup = bs4.BeautifulSoup(index.read_text(), features="lxml")
+    shutil.rmtree(example_project)  # Delete copied source
 
     # Check if field entry was created
     assert soup.find("section", {"class": "kitbash-entry"})
@@ -79,5 +84,3 @@ def test_pydantic_kitbash_integration(example_project):
         getattr(soup.find("span", {"class": "l l-Scalar l-Scalar-Plain"}), "text", None)
         == "val1"
     )
-
-    shutil.rmtree(example_project)


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Preserves the output of the integration test in a top-level file

Resolves https://github.com/canonical/pydantic-kitbash/issues/36
