### PR TITLE
feat: add cross-reference support

### DIFF
--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -794,13 +794,10 @@ def parse_rst_description(
         list[Node]: the docutils nodes produced by the rST
 
     """
-    if hasattr(directive, "state") and hasattr(directive, "env"):
-        settings = directive.state.document.settings
-        rst_doc = new_document(directive.env.docname, settings=settings)
-        rst_parser = Parser()
-        rst_parser.parse(strip_whitespace(rst_desc), rst_doc)
-    else:
-        rst_doc = cast(nodes.document, publish_doctree(strip_whitespace(rst_desc)))
+    settings = directive.state.document.settings
+    rst_doc = new_document(directive.env.docname, settings=settings)
+    rst_parser = Parser()
+    rst_parser.parse(strip_whitespace(rst_desc), rst_doc)
 
     return list(rst_doc.children)
 

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -34,7 +34,8 @@ import pydantic
 import yaml
 from docutils import nodes
 from docutils.core import publish_doctree  # type: ignore[reportUnknownVariableType]
-from docutils.parsers.rst import directives
+from docutils.parsers.rst import Parser, directives
+from docutils.utils import new_document
 from pydantic.fields import FieldInfo
 from sphinx.util.docutils import SphinxDirective
 from typing_extensions import override
@@ -50,6 +51,7 @@ class FieldEntry:
     """Contains any field attributes that will be displayed in directive output."""
 
     name: str
+    parent_directive: SphinxDirective
     alias: str
     label: str
     deprecation_warning: str | None
@@ -58,8 +60,9 @@ class FieldEntry:
     enum_values: list[list[str]] | None
     examples: list[str] | None
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, parent_directive: SphinxDirective) -> None:
         self.name = name
+        self.parent_directive = parent_directive
         self.alias = name
         self.label = name
         self.deprecation_warning = None
@@ -112,7 +115,7 @@ class KitbashFieldDirective(SphinxDirective):
         if self.arguments[1] not in pydantic_class.__annotations__:
             raise ValueError(f"Could not find field: {self.arguments[1]}")
 
-        field_entry = FieldEntry(self.arguments[1])
+        field_entry = FieldEntry(self.arguments[1], self)
 
         # grab pydantic field data
         field_params = pydantic_class.model_fields[field_entry.name]
@@ -220,9 +223,6 @@ class KitbashModelDirective(SphinxDirective):
         to produce a formatted output in accordance with Starcraft's YAML key
         documentation standard.
 
-        Args:
-            self: Object containing the directive's state.
-
         Returns:
             list[nodes.Node]: Well-formed list of nodes to render into field entries.
 
@@ -238,9 +238,9 @@ class KitbashModelDirective(SphinxDirective):
 
         # User-provided description overrides model docstring
         if self.content:
-            class_node += parse_rst_description("\n".join(self.content))
+            class_node += parse_rst_description("\n".join(self.content), self)
         elif pydantic_class.__doc__ and "skip-description" not in self.options:
-            class_node += parse_rst_description(pydantic_class.__doc__)
+            class_node += parse_rst_description(pydantic_class.__doc__, self)
 
         # Check if user provided a list of deprecated fields to include
         include_deprecated = [
@@ -263,7 +263,7 @@ class KitbashModelDirective(SphinxDirective):
                 # grab pydantic field data (need desc and examples)
                 field_params = pydantic_class.model_fields[field]
 
-                field_entry = FieldEntry(field)
+                field_entry = FieldEntry(field, self)
                 field_entry.deprecation_warning = deprecation_warning
 
                 field_entry.alias = (
@@ -355,7 +355,6 @@ def get_optional_field_data(field_entry: FieldEntry, annotation: type[Any]) -> N
 
     Args:
         field_entry (FieldEntry): Object containing field data.
-
         annotation (type[Any]): Type annotation of the optional field. This field
             may be either a standard Python type or an optional enum.
 
@@ -381,7 +380,6 @@ def get_optional_annotated_field_data(
 
     Args:
         field_entry (FieldEntry): Object containing field data.
-
         annotation (type[Any]): Annotation of an optional annotated type field.
 
     Returns:
@@ -411,7 +409,6 @@ def get_enum_field_data(field_entry: FieldEntry, annotation: type[Any] | None) -
 
     Args:
         field_entry (FieldEntry): Object containing field data.
-
         annotation (type[Any]): Annotation for an enum field. This does not include
             optional enum fields, which are handled by `get_optional_field_data`.
 
@@ -524,7 +521,9 @@ def create_field_node(field_entry: FieldEntry) -> nodes.section:
 
     if field_entry.deprecation_warning:
         deprecated_node = nodes.important()
-        deprecated_node += parse_rst_description(field_entry.deprecation_warning)
+        deprecated_node += parse_rst_description(
+            field_entry.deprecation_warning, field_entry.parent_directive
+        )
         field_node += deprecated_node
 
     if field_entry.field_type:
@@ -547,13 +546,17 @@ def create_field_node(field_entry: FieldEntry) -> nodes.section:
         desc_header = nodes.paragraph()
         desc_header += nodes.strong(text="Description")
         field_node += desc_header
-        field_node += parse_rst_description(field_entry.description)
+        field_node += parse_rst_description(
+            field_entry.description, field_entry.parent_directive
+        )
 
     if field_entry.enum_values:
         values_header = nodes.paragraph()
         values_header += nodes.strong(text="Values")
         field_node += values_header
-        field_node += create_table_node(field_entry.enum_values)
+        field_node += create_table_node(
+            field_entry.enum_values, field_entry.parent_directive
+        )
 
     if field_entry.examples:
         examples_header = nodes.paragraph()
@@ -603,13 +606,16 @@ def build_examples_block(field_name: str, example: str) -> nodes.literal_block:
     return examples_block
 
 
-def create_table_node(values: list[list[str]]) -> nodes.container:
+def create_table_node(
+    values: list[list[str]], parent_directive: SphinxDirective
+) -> nodes.container:
     """Create docutils table node.
 
     Creates a container node containing a properly formatted table node.
 
     Args:
         values (list[list[str]]): A list of value-description pairs.
+        parent_directive(SphinxDirective): The directive that outputs the returned nodes.
 
     Returns:
         nodes.container: A `div` containing a well-formed docutils table.
@@ -643,12 +649,12 @@ def create_table_node(values: list[list[str]]) -> nodes.container:
     tgroup += tbody
 
     for row in values:
-        tbody += create_table_row(row)
+        tbody += create_table_row(row, parent_directive)
 
     return div_node
 
 
-def create_table_row(values: list[str]) -> nodes.row:
+def create_table_row(values: list[str], parent_directive: SphinxDirective) -> nodes.row:
     """Create well-formed docutils table row.
 
     Creates a well-structured docutils table row from
@@ -656,6 +662,7 @@ def create_table_row(values: list[str]) -> nodes.row:
 
     Args:
         values (list[str]): A list containing a value and description.
+        parent_directive(SphinxDirective): The directive that outputs the returned nodes.
 
     Returns:
         nodes.row: A table row consisting of the provided value and description.
@@ -670,7 +677,7 @@ def create_table_row(values: list[str]) -> nodes.row:
     row += value_entry
 
     desc_entry = nodes.entry()
-    desc_entry += parse_rst_description(values[1])
+    desc_entry += parse_rst_description(values[1], parent_directive)
     row += desc_entry
 
     return row
@@ -708,7 +715,7 @@ def get_annotation_docstring(cls: type[object], annotation_name: str) -> str | N
         ):
             found = True
 
-    return docstring
+    return cast(str, docstring)
 
 
 def get_enum_member_docstring(cls: type[object], enum_member: str) -> str | None:
@@ -769,20 +776,29 @@ def get_enum_values(enum_class: type[object]) -> list[list[str]]:
     return enum_docstrings
 
 
-def parse_rst_description(rst_desc: str) -> list[nodes.Node]:
+def parse_rst_description(
+    rst_desc: str, directive: SphinxDirective
+) -> list[nodes.Node]:
     """Parse rST from model and field docstrings.
 
     Creates a reStructuredText document node from the given string so that
     the document's child nodes can be appended to the directive's output.
+    This method requires the parent_directive to enable cross-references,
+    which cannot be resolved without a reference to the parent doctree.
 
     Args:
         rst_desc (str): string containing reStructuredText
+        directive (SphinxDirective): The directive that outputs the returned nodes.
 
     Returns:
         list[Node]: the docutils nodes produced by the rST
 
     """
-    rst_doc = cast(nodes.document, publish_doctree(strip_whitespace(rst_desc)))
+    settings = directive.state.document.settings
+    rst_doc = new_document(directive.env.docname, settings=settings)
+
+    rst_parser = Parser()
+    rst_parser.parse(strip_whitespace(rst_desc), rst_doc)
 
     return list(rst_doc.children)
 

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -794,11 +794,13 @@ def parse_rst_description(
         list[Node]: the docutils nodes produced by the rST
 
     """
-    settings = directive.state.document.settings
-    rst_doc = new_document(directive.env.docname, settings=settings)
-
-    rst_parser = Parser()
-    rst_parser.parse(strip_whitespace(rst_desc), rst_doc)
+    if hasattr(directive, "state") and hasattr(directive, "env"):
+        settings = directive.state.document.settings
+        rst_doc = new_document(directive.env.docname, settings=settings)
+        rst_parser = Parser()
+        rst_parser.parse(strip_whitespace(rst_desc), rst_doc)
+    else:
+        rst_doc = cast(nodes.document, publish_doctree(strip_whitespace(rst_desc)))
 
     return list(rst_doc.children)
 

--- a/tests/integration/example/index.rst
+++ b/tests/integration/example/index.rst
@@ -1,6 +1,7 @@
-
 Fields
 ======
+
+.. Test default and manual labels
 
 :ref:`Automatic label <index-test>`
 
@@ -10,3 +11,15 @@ Fields
 
 .. kitbash-field:: example.project.MockModel mock_field
     :label: cool-beans
+
+
+.. Test internal references in field descriptions and docstrings
+
+.. kitbash-field:: example.project.MockModel xref_desc_test
+
+.. kitbash-field:: example.project.MockModel xref_docstring_test
+
+.. toctree::
+    :hidden:
+
+    the-other-file

--- a/tests/integration/example/project.py
+++ b/tests/integration/example/project.py
@@ -26,3 +26,8 @@ class MockModel(pydantic.BaseModel):
         alias="test",
         deprecated="ew.",
     )
+
+    xref_desc_test: str = pydantic.Field(description=":ref:`the-other-file`")
+
+    xref_docstring_test: str = pydantic.Field(description="ignored")
+    """:ref:`the-other-file`"""

--- a/tests/integration/example/the-other-file.rst
+++ b/tests/integration/example/the-other-file.rst
@@ -1,0 +1,6 @@
+.. _the-other-file:
+
+The other file
+==============
+
+Wow, you can put cross-references in docstrings now? What a great feature!

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,175 @@
+import enum
+from typing import Annotated, Any
+
+import pydantic
+import pytest
+from docutils.statemachine import StringList
+from pydantic_kitbash.directives import KitbashFieldDirective, KitbashModelDirective
+from typing_extensions import override
+
+
+class FakeFieldDirective(KitbashFieldDirective):
+    """An override for testing only our additions."""
+
+    @override
+    def __init__(
+        self,
+        name: str,
+        arguments: list[str],
+        options: dict[str, Any],
+        content: StringList,
+    ):
+        self.name = name
+        self.arguments = arguments
+        self.options = options
+        self.content = content
+
+
+@pytest.fixture
+def fake_field_directive(request: pytest.FixtureRequest) -> FakeFieldDirective:
+    """This fixture can be parametrized to override the default values.
+
+    Most parameters are 1:1 with the init function of FakeFieldDirective, but
+    there is one exception - the "model_field" key can be used as a shorthand
+    to more easily select a field on the MockModel in this file instead of
+    passing a fully qualified module name.
+    """
+    # Get any optional overrides from the fixtures
+    overrides = request.param if hasattr(request, "param") else {}
+
+    # Handle the model_field shorthand
+    if value := overrides.get("model_field"):
+        arguments = [fake_field_directive.__module__ + ".MockFieldModel", value]
+    elif value := overrides.get("arguments"):
+        arguments = value
+    else:
+        arguments = [fake_field_directive.__module__ + ".MockFieldModel", "mock_field"]
+
+    return FakeFieldDirective(
+        name=overrides.get("name", "kitbash-field"),
+        arguments=arguments,
+        options=overrides.get("options", {}),
+        content=overrides.get("content", []),
+    )
+
+
+class FakeModelDirective(KitbashModelDirective):
+    """An override for testing only our additions."""
+
+    @override
+    def __init__(
+        self,
+        name: str,
+        arguments: list[str],
+        options: dict[str, Any],
+        content: StringList,
+    ):
+        self.name = name
+        self.arguments = arguments
+        self.options = options
+        self.content = content
+
+
+@pytest.fixture
+def fake_model_directive(request: pytest.FixtureRequest) -> FakeModelDirective:
+    """This fixture can be parametrized to override the default values.
+
+    Most parameters are 1:1 with the init function of FakeModelDirective, but
+    there is one exception - the "model_field" key can be used as a shorthand
+    to more easily select a field on the MockModel in this file instead of
+    passing a fully qualified module name.
+    """
+    # Get any optional overrides from the fixtures
+    overrides = request.param if hasattr(request, "param") else {}
+
+    # Handle the model_field shorthand
+    if value := overrides.get("model"):
+        arguments = [fake_model_directive.__module__ + value]
+    elif value := overrides.get("arguments"):
+        arguments = value
+    else:
+        arguments = [fake_model_directive.__module__ + ".MockModel"]
+
+    return FakeModelDirective(
+        name=overrides.get("name", "kitbash-model"),
+        arguments=arguments,
+        options=overrides.get("options", {}),
+        content=overrides.get("content", []),
+    )
+
+
+def validator(
+    value: str,
+) -> str:
+    return value.strip()
+
+
+TEST_TYPE = Annotated[
+    str,
+    pydantic.AfterValidator(validator),
+    pydantic.BeforeValidator(validator),
+    pydantic.Field(
+        description="This is a typing.Union",
+    ),
+]
+
+
+TEST_TYPE_EXAMPLES = Annotated[
+    str,
+    pydantic.AfterValidator(validator),
+    pydantic.BeforeValidator(validator),
+    pydantic.Field(
+        description="This is a typing.Union",
+        examples=["str1", "str2", "str3"],
+    ),
+]
+
+
+class MockEnum(enum.Enum):
+    """Enum docstring."""
+
+    VALUE_1 = "value1"
+    """The first value."""
+
+    VALUE_2 = "value2"
+    """The second value."""
+
+
+class MockFieldModel(pydantic.BaseModel):
+    """Mock model for testing the kitbash-field directive"""
+
+    mock_field: int = pydantic.Field(
+        description="description",
+        alias="test",
+        deprecated="ew.",
+    )
+    bad_example: int = pydantic.Field(
+        description="description",
+        examples=["not good"],
+    )
+    uniontype_field: str | None = pydantic.Field(
+        description="This is types.UnionType",
+    )
+    enum_field: MockEnum
+    enum_uniontype: MockEnum | None
+    typing_union: TEST_TYPE_EXAMPLES | None
+
+
+class MockModel(pydantic.BaseModel):
+    """this is the model's docstring"""
+
+    mock_field: int = pydantic.Field(
+        description="description",
+        alias="test",
+        deprecated="ew.",
+    )
+    uniontype_field: str | None = pydantic.Field(
+        description="This is types.UnionType",
+    )
+    enum_field: MockEnum
+    enum_uniontype: MockEnum | None
+    typing_union: TEST_TYPE | None
+
+
+class OopsNoModel:
+    field1: int

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -55,12 +55,12 @@ def test_kitbash_field(fake_field_directive):
 
     # The IDs are duplicated because the test directives have no state.
     # In actual usage, the second ID will always be prefixed with the filename.
-    expected = nodes.section(ids=["test", "test"])
+    expected = nodes.section(ids=["test", "docname-test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "test"
+    target_node["refid"] = "docname-test"
     expected += target_node
 
     field_entry = """\
@@ -92,12 +92,12 @@ def test_kitbash_field(fake_field_directive):
 def test_kitbash_field_prepend_name(fake_field_directive):
     """Test for the -name options in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["prefix.test", "test"])
+    expected = nodes.section(ids=["prefix.test", "docname-test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="prefix.test")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "test"
+    target_node["refid"] = "docname-test"
     expected += target_node
 
     field_entry = """\
@@ -129,12 +129,12 @@ def test_kitbash_field_prepend_name(fake_field_directive):
 def test_kitbash_field_append_name(fake_field_directive):
     """Test for the -name options in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["test.suffix", "test"])
+    expected = nodes.section(ids=["test.suffix", "docname-test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test.suffix")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "test"
+    target_node["refid"] = "docname-test"
     expected += target_node
 
     field_entry = """\
@@ -166,12 +166,12 @@ def test_kitbash_field_append_name(fake_field_directive):
 def test_kitbash_field_override_type(fake_field_directive):
     """Test for the override-type option in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["test", "test"])
+    expected = nodes.section(ids=["test", "docname-test"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="test")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "test"
+    target_node["refid"] = "docname-test"
     expected += target_node
 
     field_entry = """\
@@ -242,12 +242,12 @@ def test_kitbash_field_label_option(fake_field_directive):
 def test_kitbash_field_skip_examples(fake_field_directive):
     """Test for the skip-examples option in KitbashFieldDirective."""
 
-    expected = nodes.section(ids=["bad_example", "bad_example"])
+    expected = nodes.section(ids=["bad_example", "docname-bad_example"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="bad_example")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "bad_example"
+    target_node["refid"] = "docname-bad_example"
     expected += target_node
 
     field_entry = """\
@@ -277,12 +277,12 @@ def test_kitbash_field_skip_examples(fake_field_directive):
 def test_kitbash_field_enum(fake_field_directive):
     """Test for the KitbashFieldDirective when passed an enum field."""
 
-    expected = nodes.section(ids=["enum_field", "enum_field"])
+    expected = nodes.section(ids=["enum_field", "docname-enum_field"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_field")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "enum_field"
+    target_node["refid"] = "docname-enum_field"
     expected += target_node
 
     field_entry = """\
@@ -317,12 +317,12 @@ def test_kitbash_field_enum(fake_field_directive):
 def test_kitbash_field_union_type(fake_field_directive):
     """Test for the KitbashFieldDirective when passed a types.UnionType field."""
 
-    expected = nodes.section(ids=["uniontype_field", "uniontype_field"])
+    expected = nodes.section(ids=["uniontype_field", "docname-uniontype_field"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="uniontype_field")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "uniontype_field"
+    target_node["refid"] = "docname-uniontype_field"
     expected += target_node
 
     field_entry = """\
@@ -352,12 +352,12 @@ def test_kitbash_field_union_type(fake_field_directive):
 def test_kitbash_field_enum_union(fake_field_directive):
     """Test for the KitbashFieldDirective when passed an enum UnionType field."""
 
-    expected = nodes.section(ids=["enum_uniontype", "enum_uniontype"])
+    expected = nodes.section(ids=["enum_uniontype", "docname-enum_uniontype"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="enum_uniontype")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "enum_uniontype"
+    target_node["refid"] = "docname-enum_uniontype"
     expected += target_node
 
     field_entry = """\
@@ -393,12 +393,12 @@ def test_kitbash_field_enum_union(fake_field_directive):
 def test_kitbash_field_typing_union(fake_field_directive):
     """Test for KitbashFieldDirective when passed a typing.Union field."""
 
-    expected = nodes.section(ids=["typing_union", "typing_union"])
+    expected = nodes.section(ids=["typing_union", "docname-typing_union"])
     expected["classes"].append("kitbash-entry")
     title_node = nodes.title(text="typing_union")
     expected += title_node
     target_node = nodes.target()
-    target_node["refid"] = "typing_union"
+    target_node["refid"] = "docname-typing_union"
     expected += target_node
 
     field_entry = """\

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -15,15 +15,13 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import enum
-from typing import Annotated, Any
+from typing import Annotated
 
 import pydantic
 import pytest
 from docutils import nodes
 from docutils.core import publish_doctree
-from docutils.statemachine import StringList
-from pydantic_kitbash.directives import KitbashFieldDirective, strip_whitespace
-from typing_extensions import override
+from pydantic_kitbash.directives import strip_whitespace
 
 LIST_TABLE_RST = """
 
@@ -40,111 +38,19 @@ LIST_TABLE_RST = """
 """
 
 
-def validator(
-    value: str,
-) -> str:
-    return value.strip()
-
-
-TEST_TYPE = Annotated[
-    str,
-    pydantic.AfterValidator(validator),
-    pydantic.BeforeValidator(validator),
-    pydantic.Field(
-        description="This is a typing.Union",
-        examples=["str1", "str2", "str3"],
-    ),
-]
-
-
-class MockEnum(enum.Enum):
-    """Enum docstring."""
-
-    VALUE_1 = "value1"
-    """The first value."""
-
-    VALUE_2 = "value2"
-    """The second value."""
-
-
-class MockModel(pydantic.BaseModel):
-    """MockModel contains fields of varying structure for testing."""
-
-    mock_field: int = pydantic.Field(
-        description="description",
-        alias="test",
-        deprecated="ew.",
-    )
-    bad_example: int = pydantic.Field(
-        description="description",
-        examples=["not good"],
-    )
-    uniontype_field: str | None = pydantic.Field(
-        description="This is types.UnionType",
-    )
-    enum_field: MockEnum
-    enum_uniontype: MockEnum | None
-    typing_union: TEST_TYPE | None
-
-
-class FakeFieldDirective(KitbashFieldDirective):
-    """An override for testing only our additions."""
-
-    @override
-    def __init__(
-        self,
-        name: str,
-        arguments: list[str],
-        options: dict[str, Any],
-        content: StringList,
-    ):
-        self.name = name
-        self.arguments = arguments
-        self.options = options
-        self.content = content
-
-
-@pytest.fixture
-def fake_field_directive(request: pytest.FixtureRequest) -> FakeFieldDirective:
-    """This fixture can be parametrized to override the default values.
-
-    Most parameters are 1:1 with the init function of FakeFieldDirective, but
-    there is one exception - the "model_field" key can be used as a shorthand
-    to more easily select a field on the MockModel in this file instead of
-    passing a fully qualified module name.
-    """
-    # Get any optional overrides from the fixtures
-    overrides = request.param if hasattr(request, "param") else {}
-
-    # Handle the model_field shorthand
-    if value := overrides.get("model_field"):
-        arguments = [fake_field_directive.__module__ + ".MockModel", value]
-    elif value := overrides.get("arguments"):
-        arguments = value
-    else:
-        arguments = [fake_field_directive.__module__ + ".MockModel", "mock_field"]
-
-    return FakeFieldDirective(
-        name=overrides.get("name", "kitbash-field"),
-        arguments=arguments,
-        options=overrides.get("options", {}),
-        content=overrides.get("content", []),
-    )
-
-
 @pytest.mark.parametrize(
     "fake_field_directive",
     [{"model_field": "i_dont_exist"}],
     indirect=True,
 )
-def test_kitbash_field_invalid(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_invalid(fake_field_directive):
     """Test for KitbashFieldDirective when passed a nonexistent field."""
 
     with pytest.raises(ValueError, match="Could not find field: i_dont_exist"):
         fake_field_directive.run()
 
 
-def test_kitbash_field(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field(fake_field_directive):
     """Test for KitbashFieldDirective."""
 
     # The IDs are duplicated because the test directives have no state.
@@ -183,7 +89,7 @@ def test_kitbash_field(fake_field_directive: FakeFieldDirective):
 @pytest.mark.parametrize(
     "fake_field_directive", [{"options": {"prepend-name": "prefix"}}], indirect=True
 )
-def test_kitbash_field_prepend_name(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_prepend_name(fake_field_directive):
     """Test for the -name options in KitbashFieldDirective."""
 
     expected = nodes.section(ids=["prefix.test", "test"])
@@ -220,7 +126,7 @@ def test_kitbash_field_prepend_name(fake_field_directive: FakeFieldDirective):
 @pytest.mark.parametrize(
     "fake_field_directive", [{"options": {"append-name": "suffix"}}], indirect=True
 )
-def test_kitbash_field_append_name(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_append_name(fake_field_directive):
     """Test for the -name options in KitbashFieldDirective."""
 
     expected = nodes.section(ids=["test.suffix", "test"])
@@ -257,7 +163,7 @@ def test_kitbash_field_append_name(fake_field_directive: FakeFieldDirective):
 @pytest.mark.parametrize(
     "fake_field_directive", [{"options": {"override-type": "override"}}], indirect=True
 )
-def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_override_type(fake_field_directive):
     """Test for the override-type option in KitbashFieldDirective."""
 
     expected = nodes.section(ids=["test", "test"])
@@ -294,7 +200,7 @@ def test_kitbash_field_override_type(fake_field_directive: FakeFieldDirective):
 @pytest.mark.parametrize(
     "fake_field_directive", [{"options": {"label": "custom-label"}}], indirect=True
 )
-def test_kitbash_field_label_option(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_label_option(fake_field_directive):
     """Test for the override-type option in KitbashFieldDirective."""
 
     expected = nodes.section(ids=["test", "custom-label"])
@@ -333,7 +239,7 @@ def test_kitbash_field_label_option(fake_field_directive: FakeFieldDirective):
     [{"model_field": "bad_example", "options": {"skip-examples": None}}],
     indirect=True,
 )
-def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_skip_examples(fake_field_directive):
     """Test for the skip-examples option in KitbashFieldDirective."""
 
     expected = nodes.section(ids=["bad_example", "bad_example"])
@@ -368,7 +274,7 @@ def test_kitbash_field_skip_examples(fake_field_directive: FakeFieldDirective):
     [{"model_field": "enum_field"}],
     indirect=True,
 )
-def test_kitbash_field_enum(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_enum(fake_field_directive):
     """Test for the KitbashFieldDirective when passed an enum field."""
 
     expected = nodes.section(ids=["enum_field", "enum_field"])
@@ -408,7 +314,7 @@ def test_kitbash_field_enum(fake_field_directive: FakeFieldDirective):
     [{"model_field": "uniontype_field"}],
     indirect=True,
 )
-def test_kitbash_field_union_type(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_union_type(fake_field_directive):
     """Test for the KitbashFieldDirective when passed a types.UnionType field."""
 
     expected = nodes.section(ids=["uniontype_field", "uniontype_field"])
@@ -443,7 +349,7 @@ def test_kitbash_field_union_type(fake_field_directive: FakeFieldDirective):
     [{"model_field": "enum_uniontype"}],
     indirect=True,
 )
-def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_enum_union(fake_field_directive):
     """Test for the KitbashFieldDirective when passed an enum UnionType field."""
 
     expected = nodes.section(ids=["enum_uniontype", "enum_uniontype"])
@@ -484,7 +390,7 @@ def test_kitbash_field_enum_union(fake_field_directive: FakeFieldDirective):
     [{"model_field": "typing_union", "options": {"skip-examples": None}}],
     indirect=True,
 )
-def test_kitbash_field_typing_union(fake_field_directive: FakeFieldDirective):
+def test_kitbash_field_typing_union(fake_field_directive):
     """Test for KitbashFieldDirective when passed a typing.Union field."""
 
     expected = nodes.section(ids=["typing_union", "typing_union"])

--- a/tests/unit/test_kitbash_model.py
+++ b/tests/unit/test_kitbash_model.py
@@ -130,7 +130,7 @@ class MockEnum(enum.Enum):
     """The second value."""
 
 
-def build_section_node(node_id: str, title: str) -> nodes.section:
+def build_section_node(title: str, node_id: str) -> nodes.section:
     """Create a section node containing all of the information for a single field.
 
     Args:
@@ -167,12 +167,12 @@ def test_kitbash_model(fake_model_directive):
 
     expected = list(publish_doctree("this is the model's docstring").children)
 
-    uniontype_section = build_section_node("uniontype_field", "uniontype_field")
+    uniontype_section = build_section_node("uniontype_field", "docname-uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum_field", "enum_field")
+    enum_section = build_section_node("enum_field", "docname-enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -180,7 +180,9 @@ def test_kitbash_model(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = build_section_node("enum_uniontype", "enum_uniontype")
+    enum_uniontype_section = build_section_node(
+        "enum_uniontype", "docname-enum_uniontype"
+    )
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
     enum_uniontype_value_container = nodes.container()
@@ -188,7 +190,7 @@ def test_kitbash_model(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = build_section_node("typing_union", "typing_union")
+    typing_union_section = build_section_node("typing_union", "docname-typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -215,12 +217,12 @@ def test_kitbash_model_skip_description(fake_model_directive):
 
     expected = []
 
-    uniontype_section = build_section_node("uniontype_field", "uniontype_field")
+    uniontype_section = build_section_node("uniontype_field", "docname-uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum_field", "enum_field")
+    enum_section = build_section_node("enum_field", "docname-enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -228,7 +230,9 @@ def test_kitbash_model_skip_description(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = build_section_node("enum_uniontype", "enum_uniontype")
+    enum_uniontype_section = build_section_node(
+        "enum_uniontype", "docname-enum_uniontype"
+    )
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
 
@@ -237,7 +241,7 @@ def test_kitbash_model_skip_description(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = build_section_node("typing_union", "typing_union")
+    typing_union_section = build_section_node("typing_union", "docname-typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -256,12 +260,12 @@ def test_kitbash_model_content(fake_model_directive):
 
     expected = list(publish_doctree("``Test content``").children)
 
-    uniontype_section = build_section_node("uniontype_field", "uniontype_field")
+    uniontype_section = build_section_node("uniontype_field", "docname-uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum_field", "enum_field")
+    enum_section = build_section_node("enum_field", "docname-enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -269,7 +273,9 @@ def test_kitbash_model_content(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = build_section_node("enum_uniontype", "enum_uniontype")
+    enum_uniontype_section = build_section_node(
+        "enum_uniontype", "docname-enum_uniontype"
+    )
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
     enum_uniontype_value_container = nodes.container()
@@ -277,7 +283,7 @@ def test_kitbash_model_content(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = build_section_node("typing_union", "typing_union")
+    typing_union_section = build_section_node("typing_union", "docname-typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -304,17 +310,17 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
 
     expected = list(publish_doctree("this is the model's docstring").children)
 
-    mock_field_section = build_section_node("test", "test")
+    mock_field_section = build_section_node("test", "docname-test")
     mock_field_rst = strip_whitespace(MOCK_FIELD_RST)
     mock_field_section += publish_doctree(mock_field_rst).children
     expected.append(mock_field_section)
 
-    uniontype_section = build_section_node("uniontype_field", "uniontype_field")
+    uniontype_section = build_section_node("uniontype_field", "docname-uniontype_field")
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum_field", "enum_field")
+    enum_section = build_section_node("enum_field", "docname-enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -322,7 +328,9 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     enum_section += enum_value_container
     expected.append(enum_section)
 
-    enum_uniontype_section = build_section_node("enum_uniontype", "enum_uniontype")
+    enum_uniontype_section = build_section_node(
+        "enum_uniontype", "docname-enum_uniontype"
+    )
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
     enum_uniontype_value_container = nodes.container()
@@ -330,7 +338,7 @@ def test_kitbash_model_include_deprecated(fake_model_directive):
     enum_uniontype_section += enum_uniontype_value_container
     expected.append(enum_uniontype_section)
 
-    typing_union_section = build_section_node("typing_union", "typing_union")
+    typing_union_section = build_section_node("typing_union", "docname-typing_union")
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children
     expected.append(typing_union_section)
@@ -359,13 +367,13 @@ def test_kitbash_model_name_options(fake_model_directive):
     expected = list(publish_doctree("this is the model's docstring").children)
 
     uniontype_section = build_section_node(
-        "uniontype_field", "prefix.uniontype_field.suffix"
+        "prefix.uniontype_field.suffix", "docname-uniontype_field"
     )
     uniontype_rst = strip_whitespace(UNIONTYPE_RST)
     uniontype_section += publish_doctree(uniontype_rst).children
     expected.append(uniontype_section)
 
-    enum_section = build_section_node("enum_field", "prefix.enum_field.suffix")
+    enum_section = build_section_node("prefix.enum_field.suffix", "docname-enum_field")
     enum_rst = strip_whitespace(ENUM_RST)
     enum_section += publish_doctree(enum_rst).children
     enum_value_container = nodes.container()
@@ -374,7 +382,7 @@ def test_kitbash_model_name_options(fake_model_directive):
     expected.append(enum_section)
 
     enum_uniontype_section = build_section_node(
-        "enum_uniontype", "prefix.enum_uniontype.suffix"
+        "prefix.enum_uniontype.suffix", "docname-enum_uniontype"
     )
     enum_uniontype_rst = strip_whitespace(ENUM_RST)
     enum_uniontype_section += publish_doctree(enum_uniontype_rst).children
@@ -384,7 +392,7 @@ def test_kitbash_model_name_options(fake_model_directive):
     expected.append(enum_uniontype_section)
 
     typing_union_section = build_section_node(
-        "typing_union", "prefix.typing_union.suffix"
+        "prefix.typing_union.suffix", "docname-typing_union"
     )
     typing_union_rst = strip_whitespace(TYPING_UNION_RST)
     typing_union_section += publish_doctree(typing_union_rst).children

--- a/tests/unit/test_supporting_functions.py
+++ b/tests/unit/test_supporting_functions.py
@@ -471,7 +471,6 @@ def test_get_optional_annotated_field_data_no_annotation(fake_field_directive):
 
     entry = FieldEntry("nom", fake_field_directive)
     get_optional_annotated_field_data(entry, annotation)
-    print(entry.field_type)
 
     assert entry.name == "nom"
     assert entry.field_type is None

--- a/tests/unit/test_supporting_functions.py
+++ b/tests/unit/test_supporting_functions.py
@@ -220,7 +220,7 @@ def test_is_enum_type_false():
     assert not is_enum_type(Model.model_fields["field"].annotation)
 
 
-def test_create_field_node():
+def test_create_field_node(fake_field_directive):
     """Test for create_field_node."""
 
     # need to set up section node manually
@@ -233,7 +233,7 @@ def test_create_field_node():
     expected += target_node
     expected += publish_doctree(KEY_ENTRY_RST).children
 
-    test_entry = FieldEntry("key-name")
+    test_entry = FieldEntry("key-name", fake_field_directive)
     test_entry.alias = "key-name"
     test_entry.label = "key-name"
     test_entry.deprecation_warning = "Don't use this."
@@ -248,7 +248,7 @@ def test_create_field_node():
     assert str(expected) == str(actual)
 
 
-def test_create_field_node_literal_list():
+def test_create_field_node_literal_list(fake_field_directive):
     """Test for create_field_node with a FieldEntry of type Literal[]."""
 
     # need to set up section node manually
@@ -261,7 +261,7 @@ def test_create_field_node_literal_list():
     expected += target_node
     expected += publish_doctree(LITERAL_LIST_ENTRY_RST).children
 
-    test_entry = FieldEntry("key-name")
+    test_entry = FieldEntry("key-name", fake_field_directive)
     test_entry.alias = "key-name"
     test_entry.label = "key-name"
     test_entry.deprecation_warning = "Don't use this."
@@ -272,7 +272,7 @@ def test_create_field_node_literal_list():
     assert str(expected) == str(actual)
 
 
-def test_create_minimal_field_node():
+def test_create_minimal_field_node(fake_field_directive):
     """Test for create_field_node with a minimal set of attributes."""
 
     # need to set up section node manually
@@ -284,7 +284,7 @@ def test_create_minimal_field_node():
     target_node["refid"] = "key-name"
     expected += target_node
 
-    test_entry = FieldEntry("key-name")
+    test_entry = FieldEntry("key-name", fake_field_directive)
 
     actual = create_field_node(test_entry)
 
@@ -336,13 +336,13 @@ def test_build_invalid_examples_block():
     assert str(expected) == str(actual)
 
 
-def test_create_table_node():
+def test_create_table_node(fake_field_directive):
     """Test for create_table_node."""
 
     expected = nodes.container()
     expected += publish_doctree(TABLE_RST).children
 
-    actual = create_table_node([["1.1", "1.2"], ["2.1", "2.2"]])
+    actual = create_table_node([["1.1", "1.2"], ["2.1", "2.2"]], fake_field_directive)
 
     # comparing strings because docutils `__eq__`
     # method compares by identity rather than state
@@ -395,13 +395,13 @@ def test_get_enum_values():
     ]
 
 
-def test_parse_rst_description():
+def test_parse_rst_description(fake_field_directive):
     """Test parse_rst_description."""
 
     # use docutils to build rST like Sphinx would
     expected = publish_doctree(RST_SAMPLE).children
     # function output
-    actual = parse_rst_description(RST_SAMPLE)
+    actual = parse_rst_description(RST_SAMPLE, fake_field_directive)
 
     # comparing strings because docutils `__eq__`
     # method compares by identity rather than state
@@ -455,7 +455,7 @@ def test_format_type_string():
     assert format_type_string(list_type) == "Literal['val1', 'val2', 'val3']"
 
 
-def test_get_optional_annotated_field_data_no_annotation():
+def test_get_optional_annotated_field_data_no_annotation(fake_field_directive):
     """\
     Test for get_optional_annotated_field_data when the first arg has no
     annotation.
@@ -469,7 +469,7 @@ def test_get_optional_annotated_field_data_no_annotation():
 
     annotation = MockModel.model_fields["field1"].annotation
 
-    entry = FieldEntry("nom")
+    entry = FieldEntry("nom", fake_field_directive)
     get_optional_annotated_field_data(entry, annotation)
     print(entry.field_type)
 
@@ -479,15 +479,15 @@ def test_get_optional_annotated_field_data_no_annotation():
     assert entry.examples is None
 
 
-def test_get_optional_annotated_field_data_none():
+def test_get_optional_annotated_field_data_none(fake_field_directive):
     """Test for get_optional_annotated_field_data when no field is provided."""
 
-    entry = FieldEntry("nice try")
+    entry = FieldEntry("nice try", fake_field_directive)
     assert get_optional_annotated_field_data(entry, None) is None
 
 
-def test_get_enum_field_data_none():
+def test_get_enum_field_data_none(fake_field_directive):
     """Test for get_enum_field_data when no annotation is provided."""
 
-    entry = FieldEntry("nice try")
+    entry = FieldEntry("nice try", fake_field_directive)
     assert get_enum_field_data(entry, None) is None

--- a/uv.lock
+++ b/uv.lock
@@ -385,7 +385,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -446,7 +446,7 @@ name = "importlib-metadata"
 version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
 wheels = [


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

* Adds a `parent_directive` attribute to `FieldEntry` so that helper functions have a reference point to the build environment
* Updates `parse_rst_description` to use `new_document` instead of `publish_doctree`. This allows for the resolution of cross-references in field descriptions and docstrings.
* Moves various fixtures and test inputs into `conftest.py`
* Adds a stripped-down Sphinx application instance to the mock directives.