### PR TITLE
fix: support block-formatted YAMl strings

### DIFF
--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -80,6 +80,13 @@ class PrettyListDumper(yaml.Dumper):
         return super().increase_indent(flow, indentless=False)
 
 
+def str_presenter(dumper: yaml.Dumper, data: str) -> yaml.nodes.ScalarNode:
+    """Use the "|" style when presenting multiline strings."""
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")  # type: ignore[reportUnknownMemberType]
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)  # type: ignore[reportUnknownMemberType]
+
+
 class KitbashFieldDirective(SphinxDirective):
     """Define the kitbash-field directive's data and behavior."""
 
@@ -581,11 +588,15 @@ def build_examples_block(field_name: str, example: str) -> nodes.literal_block:
         nodes.literal_block: A literal block containing a well-formed YAML example.
 
     """
+    PrettyListDumper.add_representer(str, str_presenter)
     example = f"{field_name.rsplit('.', maxsplit=1)[-1]}: {example}"
+    if not example.endswith("\n"):
+        example = f"{example}\n"
     try:
         yaml_str = yaml.dump(
             yaml.safe_load(example),
             Dumper=PrettyListDumper,
+            default_style=None,
             default_flow_style=False,
             sort_keys=False,
         )

--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -600,8 +600,6 @@ def build_examples_block(field_name: str, example: str) -> nodes.literal_block:
             default_flow_style=False,
             sort_keys=False,
         )
-        yaml_str = yaml_str.rstrip("\n")
-        yaml_str = yaml_str.removesuffix("...")
     except yaml.YAMLError as e:
         warnings.warn(
             f"Invalid YAML for field {field_name}: {e}",
@@ -609,6 +607,9 @@ def build_examples_block(field_name: str, example: str) -> nodes.literal_block:
             stacklevel=2,
         )
         yaml_str = example
+
+    yaml_str = yaml_str.rstrip("\n")
+    yaml_str = yaml_str.removesuffix("...")
 
     examples_block = nodes.literal_block(text=yaml_str)
     examples_block["language"] = "yaml"

--- a/tests/integration/example/index.rst
+++ b/tests/integration/example/index.rst
@@ -19,6 +19,8 @@ Fields
 
 .. kitbash-field:: example.project.MockModel xref_docstring_test
 
+.. kitbash-field:: example.project.MockModel block_string
+
 .. toctree::
     :hidden:
 

--- a/tests/integration/example/project.py
+++ b/tests/integration/example/project.py
@@ -36,9 +36,9 @@ class MockModel(pydantic.BaseModel):
         description="this has a multiline example",
         examples=[
             """
-        |
-          wow
-          so many
-          lines"""
+            |
+              wow
+              so many
+              lines"""
         ],
     )

--- a/tests/integration/example/project.py
+++ b/tests/integration/example/project.py
@@ -35,9 +35,10 @@ class MockModel(pydantic.BaseModel):
     block_string: str = pydantic.Field(
         description="this has a multiline example",
         examples=[
-            "|\
-            wow\
-            so many\
-            lines"
+            """
+        |
+          wow
+          so many
+          lines"""
         ],
     )

--- a/tests/integration/example/project.py
+++ b/tests/integration/example/project.py
@@ -31,3 +31,13 @@ class MockModel(pydantic.BaseModel):
 
     xref_docstring_test: str = pydantic.Field(description="ignored")
     """:ref:`the-other-file`"""
+
+    block_string: str = pydantic.Field(
+        description="this has a multiline example",
+        examples=[
+            "|\
+            wow\
+            so many\
+            lines"
+        ],
+    )

--- a/tests/integration/test_pydantic_kitbash.py
+++ b/tests/integration/test_pydantic_kitbash.py
@@ -50,6 +50,8 @@ def test_pydantic_kitbash_integration(example_project):
     soup = bs4.BeautifulSoup(index.read_text(), features="lxml")
     shutil.rmtree(example_project)  # Delete copied source
 
+    pytest.fail("bc i said so")
+
     # Check if field entry was created
     assert soup.find("section", {"class": "kitbash-entry"})
 

--- a/tests/integration/test_pydantic_kitbash.py
+++ b/tests/integration/test_pydantic_kitbash.py
@@ -50,8 +50,6 @@ def test_pydantic_kitbash_integration(example_project):
     soup = bs4.BeautifulSoup(index.read_text(), features="lxml")
     shutil.rmtree(example_project)  # Delete copied source
 
-    pytest.fail("bc i said so")
-
     # Check if field entry was created
     assert soup.find("section", {"class": "kitbash-entry"})
 


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Resolves https://github.com/canonical/pydantic-kitbash/issues/45