### PR TITLE
fix: check for null description before appending content

### DIFF
--- a/pydantic_kitbash/directives.py
+++ b/pydantic_kitbash/directives.py
@@ -138,12 +138,6 @@ class KitbashFieldDirective(SphinxDirective):
             else field_entry.description
         )
 
-        if self.content:
-            supplemental_description = "\n".join(self.content)
-            field_entry.description = (
-                f"{field_entry.description}\n\n{supplemental_description}"
-            )
-
         field_entry.examples = field_params.examples
         field_entry.enum_values = None
 
@@ -162,6 +156,15 @@ class KitbashFieldDirective(SphinxDirective):
         field_entry.deprecation_warning = is_deprecated(
             pydantic_model, field_entry.name
         )
+
+        # Append directive content to description
+        if self.content:
+            supplemental_description = "\n".join(self.content)
+            field_entry.description = (
+                f"{field_entry.description}\n\n{supplemental_description}"
+                if field_entry.description
+                else supplemental_description
+            )
 
         # Replace type if :override-type: directive option was used
         field_entry.field_type = self.options.get(

--- a/tests/integration/example/index.rst
+++ b/tests/integration/example/index.rst
@@ -39,6 +39,10 @@ Field directive
 
     :ref:`References <index-test>` work too!
 
+.. kitbash-field:: example.project.MockModel no_desc
+
+    This field doesn't have a description, so this should take its place.
+
 
 .. Test with py:module set
 

--- a/tests/integration/example/index.rst
+++ b/tests/integration/example/index.rst
@@ -41,7 +41,7 @@ Field directive
 
 .. kitbash-field:: example.project.MockModel no_desc
 
-    This field doesn't have a description, so this should take its place.
+    This is the only thing rendered in the description.
 
 
 .. Test with py:module set

--- a/tests/integration/example/project.py
+++ b/tests/integration/example/project.py
@@ -27,6 +27,8 @@ class MockModel(pydantic.BaseModel):
         deprecated="ew.",
     )
 
+    no_desc: str
+
     xref_desc_test: str = pydantic.Field(description=":ref:`the-other-file`")
 
     xref_docstring_test: str = pydantic.Field(description="ignored")

--- a/tests/integration/test_pydantic_kitbash.py
+++ b/tests/integration/test_pydantic_kitbash.py
@@ -86,3 +86,14 @@ def test_pydantic_kitbash_integration(example_project):
         getattr(soup.find("span", {"class": "l l-Scalar l-Scalar-Plain"}), "text", None)
         == "val1"
     )
+
+    # Check that null descriptions with content don't include 'None'
+    null_desc_entry = soup.find("section", id="no_desc")
+    if null_desc_entry:
+        field_content = null_desc_entry.find_all_next("p")
+        assert (
+            getattr(field_content[3], "text", None)
+            == "This is the only thing rendered in the description."
+        )
+    else:
+        pytest.fail("`no-desc` entry not found in output.")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -214,6 +214,7 @@ class MockFieldModel(pydantic.BaseModel):
     uniontype_field: str | None = pydantic.Field(
         description="This is types.UnionType",
     )
+    no_desc: str = pydantic.Field(alias="no-desc")
     enum_field: MockEnum
     enum_uniontype: MockEnum | None
     typing_union: TEST_TYPE_EXAMPLES | None

--- a/tests/unit/test_kitbash_field.py
+++ b/tests/unit/test_kitbash_field.py
@@ -160,6 +160,41 @@ def test_kitbash_field_content(fake_field_directive):
 
 
 @pytest.mark.parametrize(
+    "fake_field_directive",
+    [{"model_field": "no_desc", "content": ["*supplemental rST*"]}],
+    indirect=True,
+)
+def test_kitbash_field_content_no_desc(fake_field_directive):
+    """Test for KitbashFieldDirective when content is provided."""
+
+    expected = nodes.section(ids=["no-desc", "docname-no-desc"])
+    expected["classes"].append("kitbash-entry")
+    title_node = nodes.title(text="no-desc")
+    expected += title_node
+    target_node = nodes.target()
+    target_node["refid"] = "docname-no-desc"
+    expected += target_node
+
+    field_entry = """\
+
+    **Type**
+
+    ``str``
+
+    **Description**
+
+    *supplemental rST*
+
+    """
+
+    field_entry = strip_whitespace(field_entry)
+    expected += publish_doctree(field_entry).children
+    actual = fake_field_directive.run()[0]
+
+    assert str(expected) == str(actual)
+
+
+@pytest.mark.parametrize(
     "fake_field_directive", [{"options": {"prepend-name": "prefix"}}], indirect=True
 )
 def test_kitbash_field_prepend_name(fake_field_directive):


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `make lint && make test`?

---

Resolves https://github.com/canonical/pydantic-kitbash/issues/56