### PR TITLE
chore: fix lint error

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -139,7 +139,13 @@ def fake_model_directive(
 def mock_state(tmp_path) -> RSTState:
     state_machine = RSTStateMachine([], "")
     state = RSTState(state_machine)
-    document = new_document("docname", settings=get_default_settings(Parser))
+
+    # `get_default_settings` only requires that `.settings_spec` is an available field
+    # on each of its parameters. Since docutils doesn't expose that in a usable type,
+    # just check it manually here (to be sure our assumption still holds true) and then
+    # ignore the lint
+    assert hasattr(Parser, "settings_spec")
+    document = new_document("docname", settings=get_default_settings(Parser))  # type: ignore[reportArgumentType, arg-type]
 
     src_dir = tmp_path / "src"
 


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `make lint && make test`?

---

Fixes a [recent lint error](https://github.com/canonical/pydantic-kitbash/actions/runs/18250366855/job/51963962617?pr=80#step:6:21) that began surfacing. Unfortunately it didn't have a very pretty fix, but thankfully it only exists in tests.